### PR TITLE
DES-1761 - Loader/spinner to notify user that features are being fetched.

### DIFF
--- a/src/app/components/control-bar/control-bar.component.html
+++ b/src/app/components/control-bar/control-bar.component.html
@@ -16,7 +16,10 @@
                 </li>
             </ul>
             <div *ngIf="!projects.length && !loading"> <span class="label alert"> No maps! Create one to get started. </span></div>
-
+            <div *ngIf="loadingData" style="margin-left: 1rem">
+                <span>Loading Data</span>
+                <i class="fas fa-spin fa-spinner ml-4" style="margin-left: 0.5rem"></i>
+            </div>
         </div>
     </div>
     <div class="cell small-8 align-right align-middle grid-x">

--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -42,12 +42,12 @@ export class ControlBarComponent implements OnInit {
       }
     });
 
-    combineLatest(this.notificationsService.loadingOverlayData,
-                  this.notificationsService.loadingPointCloudData,
-                  this.notificationsService.loadingFeatureData)
+    combineLatest(this.geoDataService.loadingOverlayData,
+                  this.geoDataService.loadingPointCloudData,
+                  this.geoDataService.loadingFeatureData)
       .subscribe(([loadingOverlay, loadingPointCloud, loadingFeature]) => {
         // They are running
-        if (!loadingOverlay && !loadingPointCloud && !loadingFeature) {
+        if (!(loadingOverlay || loadingPointCloud || loadingFeature)) {
           this.loadingData = false;
         } else {
           this.loadingData = true;

--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -21,6 +21,7 @@ export class ControlBarComponent implements OnInit {
   public selectedProject: Project;
   public mapMouseLocation: LatLng = new LatLng(0, 0);
   private loading = true;
+  private loadingData: boolean = false;
 
   constructor(private projectsService: ProjectsService,
               private geoDataService: GeoDataService,
@@ -41,6 +42,10 @@ export class ControlBarComponent implements OnInit {
       }
     });
 
+    this.notificationsService.loadingData.subscribe(next => {
+      this.loadingData = next;
+    });
+
     this.projectsService.activeProject.subscribe(next => {
       this.selectedProject = next;
       if (this.selectedProject) {
@@ -53,6 +58,7 @@ export class ControlBarComponent implements OnInit {
     this.notificationsService.notifications.subscribe(next => {
       const hasSuccessNotification = next.some(note => note.status === 'success');
       if (hasSuccessNotification) {
+        this.notificationsService.setLoadData(false);
         this.geoDataService.getDataForProject(this.selectedProject.id);
       }
     });

--- a/src/app/services/geo-data.service.ts
+++ b/src/app/services/geo-data.service.ts
@@ -140,7 +140,7 @@ export class GeoDataService {
   }
 
   importPointCloudFileFromTapis(projectId: number, pointCloudId: number, files: Array<RemoteFile>): void {
-
+    this.notificationsService.setLoadData(true);
     const tmp = files.map( f => ({system: f.system, path: f.path}));
     const payload = {
       files: tmp
@@ -153,7 +153,7 @@ export class GeoDataService {
   }
 
   importFileFromTapis(projectId: number, files: Array<RemoteFile>): void {
-
+    this.notificationsService.setLoadData(true);
     const tmp = files.map( f => ({system: f.system, path: f.path}));
     const payload = {
       files: tmp
@@ -209,6 +209,7 @@ export class GeoDataService {
   }
 
   importFeatureAsset(projectId: number, featureId: number, payload: IFileImportRequest): void {
+    this.notificationsService.setLoadData(true);
     this.http.post<Feature>(environment.apiUrl + `/projects/${projectId}/features/${featureId}/assets/`, payload)
       .subscribe( (feature) => {
         // TODO workaround to update activeFeature, this should be done with a subscription like in addFeature()
@@ -245,6 +246,7 @@ export class GeoDataService {
 
   importOverlayFileFromTapis(projectId: number, file: RemoteFile, label: string,
                              minLat: number, maxLat: number, minLon: number, maxLon: number): void {
+    this.notificationsService.setLoadData(true);
     const payload = {
       label: label,
       system_id: file.system,

--- a/src/app/services/geo-data.service.ts
+++ b/src/app/services/geo-data.service.ts
@@ -38,6 +38,12 @@ export class GeoDataService {
   public readonly pointClouds: Observable<Array<IPointCloud>> = this._pointClouds.asObservable();
   private _featureTree: ReplaySubject<PathTree<Feature>> = new ReplaySubject<PathTree<Feature>>(1);
   public readonly featureTree$: Observable<PathTree<Feature>> = this._featureTree.asObservable();
+  private _loadingFeatureData: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  public loadingFeatureData: Observable<boolean> = this._loadingFeatureData.asObservable();
+  private _loadingPointCloudData: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  public loadingPointCloudData: Observable<boolean> = this._loadingPointCloudData.asObservable();
+  private _loadingOverlayData: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  public loadingOverlayData: Observable<boolean> = this._loadingOverlayData.asObservable();
 
   constructor(private http: HttpClient, private filterService: FilterService, private notificationsService: NotificationsService) {
 
@@ -59,7 +65,7 @@ export class GeoDataService {
 
   getFeatures(projectId: number): void {
     const qstring: string = querystring.stringify(this._assetFilters.toJson());
-    this.notificationsService.setLoadFeatureData(true);
+    this.setLoadFeatureData(true);
     this.http.get<FeatureCollection>(environment.apiUrl + `/projects/${projectId}/features/` + '?' + qstring)
       .subscribe( (fc: FeatureCollection) => {
         fc.features = fc.features.map( (feat: Feature) => new Feature(feat));
@@ -77,7 +83,7 @@ export class GeoDataService {
         this._featureTree.next(tree);
 
         this._features.next(fc);
-        this.notificationsService.setLoadFeatureData(false);
+        this.setLoadFeatureData(false);
       });
   }
 
@@ -90,10 +96,10 @@ export class GeoDataService {
   }
 
   getPointClouds(projectId: number) {
-    this.notificationsService.setLoadPointCloudData(true);
+    this.setLoadPointCloudData(true);
     this.http.get<Array<IPointCloud>>(environment.apiUrl + `/projects/${projectId}/point-cloud/`)
       .subscribe( (resp ) => {
-        this.notificationsService.setLoadPointCloudData(false);
+        this.setLoadPointCloudData(false);
         this._pointClouds.next(resp);
       });
   }
@@ -225,10 +231,10 @@ export class GeoDataService {
   }
 
   getOverlays(projectId: number): void {
-    this.notificationsService.setLoadOverlayData(true);
+    this.setLoadOverlayData(true);
     this.http.get(environment.apiUrl + `/projects/${projectId}/overlays/`).subscribe( (ovs: Array<Overlay>) => {
       this._overlays.next(ovs);
-      this.notificationsService.setLoadOverlayData(false);
+      this.setLoadOverlayData(false);
     });
   }
 
@@ -356,4 +362,15 @@ export class GeoDataService {
     this._overlays.next(null);
   }
 
+  setLoadFeatureData(isLoading: boolean): void {
+    this._loadingFeatureData.next(isLoading);
+  }
+
+  setLoadPointCloudData(isLoading: boolean): void {
+    this._loadingPointCloudData.next(isLoading);
+  }
+
+  setLoadOverlayData(isLoading: boolean): void {
+    this._loadingOverlayData.next(isLoading);
+  }
 }

--- a/src/app/services/geo-data.service.ts
+++ b/src/app/services/geo-data.service.ts
@@ -59,6 +59,7 @@ export class GeoDataService {
 
   getFeatures(projectId: number): void {
     const qstring: string = querystring.stringify(this._assetFilters.toJson());
+    this.notificationsService.setLoadFeatureData(true);
     this.http.get<FeatureCollection>(environment.apiUrl + `/projects/${projectId}/features/` + '?' + qstring)
       .subscribe( (fc: FeatureCollection) => {
         fc.features = fc.features.map( (feat: Feature) => new Feature(feat));
@@ -76,6 +77,7 @@ export class GeoDataService {
         this._featureTree.next(tree);
 
         this._features.next(fc);
+        this.notificationsService.setLoadFeatureData(false);
       });
   }
 
@@ -88,8 +90,10 @@ export class GeoDataService {
   }
 
   getPointClouds(projectId: number) {
+    this.notificationsService.setLoadPointCloudData(true);
     this.http.get<Array<IPointCloud>>(environment.apiUrl + `/projects/${projectId}/point-cloud/`)
       .subscribe( (resp ) => {
+        this.notificationsService.setLoadPointCloudData(false);
         this._pointClouds.next(resp);
       });
   }
@@ -140,7 +144,6 @@ export class GeoDataService {
   }
 
   importPointCloudFileFromTapis(projectId: number, pointCloudId: number, files: Array<RemoteFile>): void {
-    this.notificationsService.setLoadData(true);
     const tmp = files.map( f => ({system: f.system, path: f.path}));
     const payload = {
       files: tmp
@@ -153,7 +156,6 @@ export class GeoDataService {
   }
 
   importFileFromTapis(projectId: number, files: Array<RemoteFile>): void {
-    this.notificationsService.setLoadData(true);
     const tmp = files.map( f => ({system: f.system, path: f.path}));
     const payload = {
       files: tmp
@@ -209,7 +211,6 @@ export class GeoDataService {
   }
 
   importFeatureAsset(projectId: number, featureId: number, payload: IFileImportRequest): void {
-    this.notificationsService.setLoadData(true);
     this.http.post<Feature>(environment.apiUrl + `/projects/${projectId}/features/${featureId}/assets/`, payload)
       .subscribe( (feature) => {
         // TODO workaround to update activeFeature, this should be done with a subscription like in addFeature()
@@ -224,8 +225,10 @@ export class GeoDataService {
   }
 
   getOverlays(projectId: number): void {
+    this.notificationsService.setLoadOverlayData(true);
     this.http.get(environment.apiUrl + `/projects/${projectId}/overlays/`).subscribe( (ovs: Array<Overlay>) => {
       this._overlays.next(ovs);
+      this.notificationsService.setLoadOverlayData(false);
     });
   }
 
@@ -246,7 +249,6 @@ export class GeoDataService {
 
   importOverlayFileFromTapis(projectId: number, file: RemoteFile, label: string,
                              minLat: number, maxLat: number, minLon: number, maxLon: number): void {
-    this.notificationsService.setLoadData(true);
     const payload = {
       label: label,
       system_id: file.system,

--- a/src/app/services/notifications.service.ts
+++ b/src/app/services/notifications.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { ToastrService } from 'ngx-toastr';
 import {HttpClient} from '@angular/common/http';
 import {INotification} from '../models/notification';
-import {interval, Observable, ReplaySubject} from 'rxjs';
+import {interval, Observable, ReplaySubject, BehaviorSubject} from 'rxjs';
 import { environment } from '../../environments/environment';
 
 @Injectable({
@@ -15,6 +15,8 @@ export class NotificationsService {
   private environment = environment;
   private _notifications: ReplaySubject<Array<INotification>> = new ReplaySubject<Array<INotification>>(1);
   public readonly  notifications: Observable<Array<INotification>> = this._notifications.asObservable();
+  private _loadingData: BehaviorSubject<boolean> = new BehaviorSubject(null);
+  public loadingData: Observable<boolean> = this._loadingData.asObservable();
 
   constructor(private toastr: ToastrService, private http: HttpClient) {
     const timer = interval(this.TIMEOUT);
@@ -52,6 +54,10 @@ export class NotificationsService {
 
   showErrorToast(message: string): void {
     this.toastr.error(message);
+  }
+
+  setLoadData(isLoading: boolean): void {
+    this._loadingData.next(isLoading);
   }
 
 }

--- a/src/app/services/notifications.service.ts
+++ b/src/app/services/notifications.service.ts
@@ -15,8 +15,12 @@ export class NotificationsService {
   private environment = environment;
   private _notifications: ReplaySubject<Array<INotification>> = new ReplaySubject<Array<INotification>>(1);
   public readonly  notifications: Observable<Array<INotification>> = this._notifications.asObservable();
-  private _loadingData: BehaviorSubject<boolean> = new BehaviorSubject(null);
-  public loadingData: Observable<boolean> = this._loadingData.asObservable();
+  private _loadingFeatureData: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  public loadingFeatureData: Observable<boolean> = this._loadingFeatureData.asObservable();
+  private _loadingPointCloudData: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  public loadingPointCloudData: Observable<boolean> = this._loadingPointCloudData.asObservable();
+  private _loadingOverlayData: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  public loadingOverlayData: Observable<boolean> = this._loadingOverlayData.asObservable();
 
   constructor(private toastr: ToastrService, private http: HttpClient) {
     const timer = interval(this.TIMEOUT);
@@ -56,8 +60,16 @@ export class NotificationsService {
     this.toastr.error(message);
   }
 
-  setLoadData(isLoading: boolean): void {
-    this._loadingData.next(isLoading);
+  setLoadFeatureData(isLoading: boolean): void {
+    this._loadingFeatureData.next(isLoading);
+  }
+
+  setLoadPointCloudData(isLoading: boolean): void {
+    this._loadingPointCloudData.next(isLoading);
+  }
+
+  setLoadOverlayData(isLoading: boolean): void {
+    this._loadingOverlayData.next(isLoading);
   }
 
 }

--- a/src/app/services/notifications.service.ts
+++ b/src/app/services/notifications.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { ToastrService } from 'ngx-toastr';
 import {HttpClient} from '@angular/common/http';
 import {INotification} from '../models/notification';
-import {interval, Observable, ReplaySubject, BehaviorSubject} from 'rxjs';
+import {interval, Observable, ReplaySubject} from 'rxjs';
 import { environment } from '../../environments/environment';
 
 @Injectable({
@@ -15,12 +15,6 @@ export class NotificationsService {
   private environment = environment;
   private _notifications: ReplaySubject<Array<INotification>> = new ReplaySubject<Array<INotification>>(1);
   public readonly  notifications: Observable<Array<INotification>> = this._notifications.asObservable();
-  private _loadingFeatureData: BehaviorSubject<boolean> = new BehaviorSubject(false);
-  public loadingFeatureData: Observable<boolean> = this._loadingFeatureData.asObservable();
-  private _loadingPointCloudData: BehaviorSubject<boolean> = new BehaviorSubject(false);
-  public loadingPointCloudData: Observable<boolean> = this._loadingPointCloudData.asObservable();
-  private _loadingOverlayData: BehaviorSubject<boolean> = new BehaviorSubject(false);
-  public loadingOverlayData: Observable<boolean> = this._loadingOverlayData.asObservable();
 
   constructor(private toastr: ToastrService, private http: HttpClient) {
     const timer = interval(this.TIMEOUT);
@@ -58,18 +52,6 @@ export class NotificationsService {
 
   showErrorToast(message: string): void {
     this.toastr.error(message);
-  }
-
-  setLoadFeatureData(isLoading: boolean): void {
-    this._loadingFeatureData.next(isLoading);
-  }
-
-  setLoadPointCloudData(isLoading: boolean): void {
-    this._loadingPointCloudData.next(isLoading);
-  }
-
-  setLoadOverlayData(isLoading: boolean): void {
-    this._loadingOverlayData.next(isLoading);
   }
 
 }


### PR DESCRIPTION
## Overview: ##
Provides visual feedback with a spinner when importing files, especially large files that take a long time.

## PR Status: ##

* [ ] Ready.
* [X] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1761](https://jira.tacc.utexas.edu/browse/DES-1761)

## Summary of Changes: ##
Added a `loadingData` observable to keep track of loading state.
Set it to false by default and true on `import*` functions in `geo-data.service`.
Then, once the `getRecent` poll returns a success, loading state is back to false.

## Testing Steps: ##
1. Open Hazmapper and login.
2. Import a layer, point cloud, or a file through the assets panel.
3. Confirm that spinner shows on the top left section of the control bar.

## UI Photos:
![Screenshot from 2020-10-23 12-39-48](https://user-images.githubusercontent.com/9425579/97031707-3c68cc00-1550-11eb-9986-745b25514efa.png)
![Screenshot from 2020-10-23 12-52-20](https://user-images.githubusercontent.com/9425579/97031712-3e328f80-1550-11eb-8c38-1f9167c925d7.png)
![Screenshot from 2020-10-23 12-53-49](https://user-images.githubusercontent.com/9425579/97031836-66ba8980-1550-11eb-9a49-db52f41385b2.png)

## Notes: ##
I wasn't sure where the best place to put the loading state. So, I just put it in `notifications.service`.