### PR TITLE
TASK/DES-1845 - Add mouse multi-select.

### DIFF
--- a/src/app/components/file-browser/file-browser.component.html
+++ b/src/app/components/file-browser/file-browser.component.html
@@ -10,7 +10,7 @@
     <option *ngFor="let project of projects" [ngValue]="project">{{project.description}}</option>
   </optgroup>
 </select>
-<div class="fileslisting" infiniteScroll [infiniteScrollDistance]="2" [infiniteScrollThrottle]="100" [scrollWindow]="false" (scrolled)="getFiles()" (click)="this.selectedFiles.clear();">
+<div class="fileslisting" infiniteScroll [infiniteScrollDistance]="2" [infiniteScrollThrottle]="100" [scrollWindow]="false" (scrolled)="getFiles()" (click)="this.selectedFiles.clear(); firstFileIndex = undefined;">
     <div class="grid-x file-row" *ngFor="let file of filesList; let fileIndex = index" [ngClass]="{'selected':selectedFiles.has(file.path)}">
       <div class="cell medium-9 clickable" (click)="select($event, fileIndex, file)"  (dblclick)="browse(file)">
         <i class="fas fa-folder" *ngIf="file.type === 'dir'" ></i>

--- a/src/app/components/file-browser/file-browser.component.html
+++ b/src/app/components/file-browser/file-browser.component.html
@@ -10,9 +10,9 @@
     <option *ngFor="let project of projects" [ngValue]="project">{{project.description}}</option>
   </optgroup>
 </select>
-<div class="fileslisting" infiniteScroll [infiniteScrollDistance]="2" [infiniteScrollThrottle]="100" [scrollWindow]="false" (scrolled)="getFiles()">
-    <div class="grid-x file-row" *ngFor="let file of filesList" [ngClass]="{'selected':selectedFiles.has(file.path)}">
-      <div class="cell medium-9 clickable" (click)="select(file)"  (dblclick)="browse(file)">
+<div class="fileslisting" infiniteScroll [infiniteScrollDistance]="2" [infiniteScrollThrottle]="100" [scrollWindow]="false" (scrolled)="getFiles()" (click)="this.selectedFiles.clear();">
+    <div class="grid-x file-row" *ngFor="let file of filesList; let fileIndex = index" [ngClass]="{'selected':selectedFiles.has(file.path)}">
+      <div class="cell medium-9 clickable" (click)="select($event, fileIndex, file)"  (dblclick)="browse(file)">
         <i class="fas fa-folder" *ngIf="file.type === 'dir'" ></i>
         <i class="far fa-file" *ngIf="file.type !== 'dir'"></i>
         <span > {{ file.name }} </span>

--- a/src/app/components/file-browser/file-browser.component.styl
+++ b/src/app/components/file-browser/file-browser.component.styl
@@ -5,8 +5,13 @@
   .fileslisting
     height 20em
     overflow-y scroll
+    padding: 0px 20px
   .file-row
+    background: #f9f9f9
     border 1px solid transparent
+    user-select: none
+    -webkit-user-select: none
+    -moz-user-select: none
     &:hover
       border 1px solid $lightGrey;
     &.selected


### PR DESCRIPTION
## Overview: ##
Implements traditional OS gui file browser mouse selection behavior in the `file-browser-component`.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1845](https://jira.tacc.utexas.edu/browse/DES-1845)

## Summary of Changes: ##
1. [X] Change regular `Click` select to not toggle selection in file-browser-component.
2. [X] `Ctrl-Click` allows the previous behavior.
3. [X] `Shift-Click` allows ranged selections (both down and up).
4. [X] `Shift-Ctrl-Click` allows aggregate ranged selections.
5. Referenced other details from OS File Manager (Windows File Explorer, Gnome Nautilus)

## Testing Steps: ##
1. Test that each selection mechanisms work.

## UI Photos:

## Notes: ##
