### PR TITLE
Task/des 1906 tileserver issues during project switching

### DIFF
--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -28,7 +28,7 @@ export class ControlBarComponent implements OnInit {
     this.projectsService.loadingActiveProject.subscribe(value => this.loadingActiveProject = value);
     this.projectsService.loadingActiveProjectFailed.subscribe(value => this.loadingActiveProjectFailed = value);
 
-    combineLatest(this.geoDataService.loadingOverlayData,
+    combineLatest([this.geoDataService.loadingOverlayData,
                   this.geoDataService.loadingPointCloudData,
                   this.geoDataService.loadingFeatureData)
       .subscribe(([loadingOverlay, loadingPointCloud, loadingFeature]) => {

--- a/src/app/components/layers-panel/layers-panel.component.ts
+++ b/src/app/components/layers-panel/layers-panel.component.ts
@@ -115,7 +115,7 @@ export class LayersPanelComponent implements OnInit, OnDestroy {
     this.showInput(ts, false);
     name = name.trim();
     if (name.length < 512) {
-      if (name && name != ts.name) {
+      if (name && name !== ts.name) {
         ts.name = name;
         this.geoDataService.updateTileServer(this.activeProject.id, ts);
       }

--- a/src/app/components/layers-panel/layers-panel.component.ts
+++ b/src/app/components/layers-panel/layers-panel.component.ts
@@ -69,7 +69,6 @@ export class LayersPanelComponent implements OnInit {
   }
 
   deleteTileServer(ts: TileServer): void {
-    this.geoDataService.selectedTileServer = ts;
     this.geoDataService.deleteTileServer(this.activeProject.id, ts.id);
   }
 

--- a/src/app/components/layers-panel/layers-panel.component.ts
+++ b/src/app/components/layers-panel/layers-panel.component.ts
@@ -54,11 +54,6 @@ export class LayersPanelComponent implements OnInit {
     });
   }
 
-  selectBasemap(bmap: string): void {
-    this.basemap = bmap;
-    this.geoDataService.basemap = this.basemap;
-  }
-
   selectOverlay(ov): void {
     ov.isActive = !ov.isActive;
     this.geoDataService.selectOverlay(ov);

--- a/src/app/components/layers-panel/layers-panel.component.ts
+++ b/src/app/components/layers-panel/layers-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ElementRef, ViewChildren, QueryList, TemplateRef } from '@angular/core';
+import {Component, OnInit, ElementRef, ViewChildren, QueryList, TemplateRef, OnDestroy} from '@angular/core';
 import {GeoDataService} from '../../services/geo-data.service';
 import {Overlay, Project, TileServer} from '../../models/models';
 import {BsModalRef, BsModalService} from 'ngx-foundation';
@@ -8,13 +8,14 @@ import {ModalCreateTileServerComponent} from '../modal-create-tile-server/modal-
 import {ProjectsService} from '../../services/projects.service';
 import {CdkDragDrop, moveItemInArray} from '@angular/cdk/drag-drop';
 import {EnvService} from '../../services/env.service';
+import {Subscription} from 'rxjs';
 
 @Component({
   selector: 'app-layers-panel',
   templateUrl: './layers-panel.component.html',
   styleUrls: ['./layers-panel.component.styl']
 })
-export class LayersPanelComponent implements OnInit {
+export class LayersPanelComponent implements OnInit, OnDestroy {
   @ViewChildren('activeText') activeInputs: QueryList<ElementRef>;
 
   dragHeight: number;
@@ -25,6 +26,7 @@ export class LayersPanelComponent implements OnInit {
   tileServers: Array<TileServer>;
   activeProject: Project;
   modalRef: BsModalRef;
+  private subscription: Subscription = new Subscription();
 
   constructor(private geoDataService: GeoDataService,
               private bsModalService: BsModalService,
@@ -33,25 +35,29 @@ export class LayersPanelComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.geoDataService.overlays.subscribe((ovs) => {
+    this.subscription.add(this.geoDataService.overlays.subscribe((ovs) => {
       this.overlays = ovs;
-    });
+    }));
 
-    this.geoDataService.tileServers.subscribe((tsv) => {
+    this.subscription.add(this.geoDataService.tileServers.subscribe((tsv) => {
       this.tileServers = tsv;
-    });
+    }));
 
-    this.geoDataService.basemap.subscribe( (next) => {
+    this.subscription.add(this.geoDataService.basemap.subscribe( (next) => {
       this.basemap = next;
-    });
+    }));
 
-    this.geoDataService.dirtyTileOptions.subscribe( (next) => {
+    this.subscription.add(this.geoDataService.dirtyTileOptions.subscribe( (next) => {
       this.dirtyOptions = next;
-    });
+    }));
 
-    this.projectsService.activeProject.subscribe( (next) => {
+    this.subscription.add(this.projectsService.activeProject.subscribe( (next) => {
       this.activeProject = next;
-    });
+    }));
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
   }
 
   selectOverlay(ov): void {

--- a/src/app/components/main-project/main-project.component.ts
+++ b/src/app/components/main-project/main-project.component.ts
@@ -23,8 +23,5 @@ export class MainProjectComponent implements OnInit {
     this.geoDataService.activeFeature.subscribe(next => {
       this.activeFeature = next;
     });
-
-    // FIXME: There's a bug related to switching projects and the tile-servers implementation
-    //        Tiles don't hide on switch (https://jira.tacc.utexas.edu/browse/DES-1906)
   }
 }

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -42,9 +42,6 @@ export class MapComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    // const mapType: string = this.route.snapshot.queryParamMap.get('mapType');
-    // this.projectId = +this.route.snapshot.paramMap.get("projectId");
-    // this.cluster = this.route.snapshot.queryParamMap.get('mapType');
     this.map = new L.Map('map', {
       center: [40, -80],
       zoom: 3,

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -123,9 +123,9 @@ export class MapComponent implements OnInit, OnDestroy {
       ...ts.tileOptions
     }
 
-    if (ts.type == 'tms') {
+    if (ts.type === 'tms') {
       return L.tileLayer(ts.url, layerOptions);
-    } else if (ts.type == 'wms') {
+    } else if (ts.type === 'wms') {
       return L.tileLayer.wms(ts.url, layerOptions);
     }
   }

--- a/src/app/services/geo-data.service.ts
+++ b/src/app/services/geo-data.service.ts
@@ -31,7 +31,7 @@ export class GeoDataService {
   private activeOverlay$: Observable<Overlay> = this._activeOverlay.asObservable();
   private _selectedOverlays: BehaviorSubject<Array<Overlay>> = new BehaviorSubject<Array<Overlay>>([]);
   public readonly selectedOverlays$: Observable<Array<Overlay>> = this._selectedOverlays.asObservable();
-  private _tileServers: BehaviorSubject<any> = new BehaviorSubject<Array<TileServer>>(null);
+  private _tileServers: BehaviorSubject<any> = new BehaviorSubject<Array<TileServer>>([]);
   private tileServers$: Observable<Array<TileServer>> = this._tileServers.asObservable();
   private _pointClouds: BehaviorSubject<Array<IPointCloud>> = new BehaviorSubject<Array<IPointCloud>>(null);
   private _assetFilters: AssetFilters;
@@ -48,8 +48,6 @@ export class GeoDataService {
   private qmsSearchResults$: Observable<Array<any>> = this._qmsSearchResults.asObservable();
   private _qmsServerResult: BehaviorSubject<any> = new BehaviorSubject<any>(null);
   private qmsServerResult$: Observable<any> = this._qmsServerResult.asObservable();
-  private _selectedTileServer: BehaviorSubject<TileServer> = new BehaviorSubject<TileServer>(null);
-  public readonly selectedTileServer$: Observable<TileServer> = this._selectedTileServer.asObservable();
   private _dirtyTileOptions: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public readonly dirtyTileOptions$: Observable<boolean> = this._dirtyTileOptions.asObservable();
 
@@ -463,14 +461,6 @@ export class GeoDataService {
     return this.tileServers$;
   }
 
-  public get selectedTileServer(): any {
-    return this.selectedTileServer$;
-  }
-
-  public set selectedTileServer(ts) {
-    this._selectedTileServer.next(ts);
-  }
-
   public get features(): Observable<FeatureCollection> {
     return this.features$;
   }
@@ -528,7 +518,8 @@ export class GeoDataService {
     //this._activeFeature.next(null);
     this._features.next({type: 'FeatureCollection', features: []});
     this._pointClouds.next(null);
-    this._overlays.next(null);
+    this._overlays.next([]);
+    this._tileServers.next([]);
   }
 
   setLoadFeatureData(isLoading: boolean): void {

--- a/src/app/services/geo-data.service.ts
+++ b/src/app/services/geo-data.service.ts
@@ -372,7 +372,12 @@ export class GeoDataService {
     });
   }
 
-  addTileServer(projectId: number, tileServer: TileServer) {
+  /**
+   * Add tile server
+   *
+   * @param quiet if set to true then toasts notifying of creation are skipped
+   */
+  addTileServer(projectId: number, tileServer: TileServer, quiet: boolean = false) {
     // NOTE: Here to give new layers zIndices without affecting previous order
     this.tileServers$.pipe(take(1)).subscribe(tileServerList => {
       if (tileServerList) {
@@ -390,7 +395,9 @@ export class GeoDataService {
     this.http.post(this.envService.apiUrl + `/projects/${projectId}/tile-servers/`, tileServer)
       .subscribe((resp) => {
         this.getTileServers(projectId);
-        this.notificationsService.showSuccessToast('Tile server ' + tileServer.name + ' added!');
+        if (!quiet) {
+          this.notificationsService.showSuccessToast('Tile server ' + tileServer.name + ' added!');
+        }
       }, (error => {
         this.notificationsService.showErrorToast('Could not add tile server!');
       }));

--- a/src/app/services/geo-data.service.ts
+++ b/src/app/services/geo-data.service.ts
@@ -333,7 +333,7 @@ export class GeoDataService {
       take(1),
       map((tss: Array<TileServer>) =>
         tss.map((ts: TileServer) =>
-          ts.id == tileServer.id ? tileServer : ts)),
+          ts.id === tileServer.id ? tileServer : ts)),
     ).subscribe((results) =>  {
       this._tileServers.next(results);
       this._dirtyTileOptions.next(true);

--- a/src/app/services/geo-data.service.ts
+++ b/src/app/services/geo-data.service.ts
@@ -313,7 +313,14 @@ export class GeoDataService {
           map((items: Array<TileServer>) =>
             items.filter((item: TileServer) =>
               item.id !== tileServerId)),
-        ).subscribe((results) =>  {
+        ).subscribe((results) => {
+
+          if (!Array.isArray(results) || !results.length) {
+            // if empty, then we should set dirty flag to false
+            // (see https://jira.tacc.utexas.edu/browse/DES-1910 for additional improvement)
+            this._dirtyTileOptions.next(false);
+          }
+
           this._tileServers.next(results);
           this.notificationsService.showSuccessToast('Tile layer deleted!');
         });

--- a/src/app/services/projects.service.ts
+++ b/src/app/services/projects.service.ts
@@ -85,12 +85,9 @@ export class ProjectsService {
         tap(proj => {
           // Spread operator, just pushes the new project into the array
           this._projects.next([...this._projects.value, proj]);
-          // Set the active project to the one just created?
-          this._activeProject.next(proj);
-
           // Add default servers
           defaultTileServers.forEach(ts => {
-            this.geoDataService.addTileServer(proj.id, ts);
+            this.geoDataService.addTileServer(proj.id, ts, true);
           });
 
         }),

--- a/src/app/services/projects.service.ts
+++ b/src/app/services/projects.service.ts
@@ -99,8 +99,6 @@ export class ProjectsService {
       .pipe(
         map( (proj) => {
           this._projects.next([proj, ...this._projects.value]);
-          // Set the active project to the one just created
-          this._activeProject.next(proj);
           return proj;
         }),
        catchError( (err: any) =>  {


### PR DESCRIPTION
## Overview: ##

Fix some issues related to switching projects and tile servers

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-1906](https://jira.tacc.utexas.edu/browse/DES-1906)

## Summary of Changes: ##

- Disable toasts for creation of default tiles for new maps
- Stop switching to active project in `ProjectServce.create()` (now handled by route change)
- Ensure we unsubscribe to our rxjs observables in `control-bar` (was causing multiple requests)
- Other minor fixes

## Testing Steps: ##

Test subscribing of observables
1.  Switch between projects on welcome screen
2. Ensure that when a new project is selected the project data (features, tile layers etc) are only requested once

Test tile layers
1.  Switch between projects on welcome screen (projects with unique tile layers. For example a map with no tile layers, a map with a tile layer, another map with a different tile layer).
2. Ensure that when a new project is selected, a user sees the NO tile layers when the map is being loaded and then, once loaded, just the tile layers of the selected map.

## UI Photos:

## Notes: ##
- added ticket related to reviewing our other subscriptions in other components ([DES-1907](https://jira.tacc.utexas.edu/browse/DES-1907))
-  added ticket for layer dragging sometimes stops working when in devtools ( [DES-1908](https://jira.tacc.utexas.edu/browse/DES-1908)
- added low priority ticket related to updating tile flag ( [DES-1910](https://jira.tacc.utexas.edu/browse/DES-1910)
