### PR TITLE
Task/DES-1934 Fix broken routing in staging deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install
 WORKDIR /
 COPY . /www
 WORKDIR /www
-RUN ng build --prod --base-href "./"
+RUN ng build --prod --base-href "/"
 RUN ls
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install
 WORKDIR /
 COPY . /www
 WORKDIR /www
-RUN ng build --prod --base-href "/"
+RUN ng build --prod
 RUN ls
 
 

--- a/src/index.html
+++ b/src/index.html
@@ -11,13 +11,25 @@
     gtag('config', 'UA-125525035-16');
   </script>
 
+
   <meta charset="utf-8">
   <title>HazMapper</title>
-  <base href="/">
-
+  <base id="base">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+  <script>
+    var hostname = window.location.hostname;
+    var pathname = window.location.pathname;
+
+    if (/^hazmapper.tacc.utexas.edu/.test(hostname) && pathname.startsWith('/staging')) {
+      document.getElementById('base').href = '/staging/';
+    } else if (/^hazmapper.tacc.utexas.edu/.test(hostname)) {
+      document.getElementById('base').href = '/hazmapper/';
+    } else {
+      document.getElementById('base').href = '/';
+    }
+  </script>
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Overview: ##

 Fix broken routing in staging deployment by fixing our staging/production docker image

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-1934](https://jira.tacc.utexas.edu/browse/DES-1934)

## Summary of Changes: ##
Removed use of `--base-href` in ng build
Set base href dynamically based on hostname/path

## Testing Steps: ##

Image (taccaci/hazmapper:41ad336) has been deployed and being used at hazmapper.tacc.utexas.edu/staging
1.  go to hazmapper.tacc.utexas.edu/staging
2. navigate to a project
3. reload on project and confirm that works
4. try other things?

## Notes: ##
I made minor change to `nginx.conf` on hazmapper.tacc.utexas.edu