### PR TITLE
Fix missing delete of hazmapper service

### DIFF
--- a/kube/Makefile
+++ b/kube/Makefile
@@ -32,6 +32,7 @@ create: checkforcontext checkfortag
 delete: checkforcontext
 	@echo "Deleting hazmapper deployment in '$(KUBE_CONTEXT)' context"
 	kubectl delete --context $(KUBE_CONTEXT) --ignore-not-found=true deployment hazmapper 
+	kubectl delete --context $(KUBE_CONTEXT) --ignore-not-found=true service hazmapper
 
 .PHONY: delete-staging
 delete-staging: KUBE_CONTEXT=geoapi-dev


### PR DESCRIPTION
## Overview: ##
Follow on to DES-1950:  There was a missing deletion of the hazmapper service.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-1950](https://jira.tacc.utexas.edu/browse/DES-1950)
