### PR TITLE
Task/DES-2006: Add ability to display custom styles and icons on map.

### DIFF
--- a/src/app/models/models.ts
+++ b/src/app/models/models.ts
@@ -2,7 +2,6 @@ import {Feature as GeoJSONFeature,
   GeoJsonProperties,
   Geometry,
   FeatureCollection as IFeatureCollection } from 'geojson';
-import { MarkerOptions } from 'leaflet';
 
 // TODO: break these out into their own files
 
@@ -215,15 +214,4 @@ export interface DesignSafeProject {
 
 export interface DesignSafeProjectCollection {
   projects: DesignSafeProject[];
-}
-
-export interface MarkerIcon {
-  color: string;
-  name: string;
-}
-
-export interface MarkerConfig {
-  type: string;
-  icon?: MarkerIcon;
-  options?: MarkerOptions;
 }

--- a/src/app/models/models.ts
+++ b/src/app/models/models.ts
@@ -2,7 +2,7 @@ import {Feature as GeoJSONFeature,
   GeoJsonProperties,
   Geometry,
   FeatureCollection as IFeatureCollection } from 'geojson';
-
+import { MarkerOptions } from 'leaflet';
 
 // TODO: break these out into their own files
 
@@ -215,4 +215,15 @@ export interface DesignSafeProject {
 
 export interface DesignSafeProjectCollection {
   projects: DesignSafeProject[];
+}
+
+export interface MarkerIcon {
+  color: string;
+  name: string;
+}
+
+export interface MarkerConfig {
+  type: string;
+  icon?: MarkerIcon;
+  options?: MarkerOptions;
 }

--- a/src/app/models/style.ts
+++ b/src/app/models/style.ts
@@ -1,0 +1,6 @@
+import {PathOptions, MarkerOptions} from 'leaflet';
+
+export interface MarkerStyle extends PathOptions, MarkerOptions {
+  faIcon?: string;
+  radius?: number;
+}

--- a/src/app/utils/leafletUtils.ts
+++ b/src/app/utils/leafletUtils.ts
@@ -50,12 +50,11 @@ function createCustomCircleMarker(latlng: LatLng, style: MarkerStyle): CircleMar
 }
 
 export function createMarker(feature: Feature, latlng: LatLng): Marker | CircleMarker {
-  if (feature.properties.customMarker) {
-    const markerType = feature.properties.customMarker;
+  if (feature.properties.style) {
     const style = feature.properties.style;
-    if (markerType === 'icon') {
+    if (style.faIcon) {
       return createCustomIconMarker(latlng, style);
-    } else if (markerType === 'styled') {
+    } else {
       return createCustomCircleMarker(latlng, style);
     }
   } else {
@@ -65,8 +64,8 @@ export function createMarker(feature: Feature, latlng: LatLng): Marker | CircleM
       return createCollectionMarker(feature, latlng);
     } else if (feature.featureType() === 'video') {
       return createVideoMarker(feature, latlng);
+    } else {
+      return createCircleMarker(feature, latlng);
     }
   }
-
-  return createCircleMarker(feature, latlng);
 }

--- a/src/app/utils/leafletUtils.ts
+++ b/src/app/utils/leafletUtils.ts
@@ -1,5 +1,6 @@
-import {CircleMarker, MarkerOptions, Path, circleMarker, divIcon, LatLng, Marker, marker} from 'leaflet';
+import {CircleMarker, Path, circleMarker, divIcon, LatLng, Marker, marker} from 'leaflet';
 import {Feature} from '../models/models';
+import {MarkerStyle} from '../models/style';
 
 interface MarkerIcon {
   color: string;
@@ -36,23 +37,26 @@ function createVideoMarker(feature: Feature, latlng: LatLng): Marker {
   return marker(latlng, {icon: ico});
 }
 
-function createCustomIconMarker(feature: Feature, latlng: LatLng): Marker {
-  const icon = feature.properties.icon as MarkerIcon;
-  const divHtml = `<i class="fas ${icon.name} fa-2x" style="color: ${icon.color}"></i>`;
+function createCustomIconMarker(latlng: LatLng, style: MarkerStyle): Marker {
+  const icon = style.faIcon;
+  const color = style.color;
+  const divHtml = `<i class="fas ${icon} fa-2x" style="color: ${color}"></i>`;
   const ico = divIcon({className: 'leaflet-fa-marker-icon', html: divHtml});
-  return marker(latlng, {icon: ico, ...feature.styles});
+  return marker(latlng, {icon: ico, ...style});
 }
 
-function createCustomCircleMarker(latlng: LatLng, options: MarkerOptions): CircleMarker {
-  return circleMarker(latlng, options);
+function createCustomCircleMarker(latlng: LatLng, style: MarkerStyle): CircleMarker {
+  return circleMarker(latlng, style);
 }
 
 export function createMarker(feature: Feature, latlng: LatLng): Marker | CircleMarker {
   if (feature.properties.customMarker) {
-    if (feature.properties.customMarker === 'icon') {
-      return createCustomIconMarker(feature, latlng);
-    } else { // 'styled'
-      return createCustomCircleMarker(latlng, feature.styles as MarkerOptions);
+    const markerType = feature.properties.customMarker;
+    const style = feature.properties.style;
+    if (markerType === 'icon') {
+      return createCustomIconMarker(latlng, style);
+    } else if (markerType === 'styled') {
+      return createCustomCircleMarker(latlng, style);
     }
   } else {
     if (feature.featureType() === 'image') {
@@ -61,8 +65,8 @@ export function createMarker(feature: Feature, latlng: LatLng): Marker | CircleM
       return createCollectionMarker(feature, latlng);
     } else if (feature.featureType() === 'video') {
       return createVideoMarker(feature, latlng);
-    } else {
-      return createCircleMarker(feature, latlng);
     }
   }
+
+  return createCircleMarker(feature, latlng);
 }

--- a/src/app/utils/leafletUtils.ts
+++ b/src/app/utils/leafletUtils.ts
@@ -1,5 +1,10 @@
-import {CircleMarker, MarkerOptions, circleMarker, divIcon, LatLng, Marker, marker} from 'leaflet';
-import {Feature, MarkerConfig, Path, MarkerIcon} from '../models/models';
+import {CircleMarker, MarkerOptions, Path, circleMarker, divIcon, LatLng, Marker, marker} from 'leaflet';
+import {Feature} from '../models/models';
+
+interface MarkerIcon {
+  color: string;
+  name: string;
+}
 
 function createCircleMarker(feature: Feature, latlng: LatLng): CircleMarker {
   const options = {
@@ -31,7 +36,18 @@ function createVideoMarker(feature: Feature, latlng: LatLng): Marker {
   return marker(latlng, {icon: ico});
 }
 
-export function createMarker(feature: Feature, latlng: LatLng): Path {
+function createCustomIconMarker(feature: Feature, latlng: LatLng): Marker {
+  const icon = feature.properties.icon as MarkerIcon;
+  const divHtml = `<i class="fas ${icon.name} fa-2x" style="color: ${icon.color}"></i>`;
+  const ico = divIcon({className: 'leaflet-fa-marker-icon', html: divHtml});
+  return marker(latlng, {icon: ico, ...feature.styles});
+}
+
+function createCustomCircleMarker(latlng: LatLng, options: MarkerOptions): CircleMarker {
+  return circleMarker(latlng, options);
+}
+
+export function createMarker(feature: Feature, latlng: LatLng): Marker | CircleMarker {
   if (feature.properties.customMarker) {
     if (feature.properties.customMarker === 'icon') {
       return createCustomIconMarker(feature, latlng);
@@ -49,15 +65,4 @@ export function createMarker(feature: Feature, latlng: LatLng): Path {
       return createCircleMarker(feature, latlng);
     }
   }
-}
-
-function createCustomIconMarker(feature: Feature, latlng: LatLng): Marker {
-  const icon = feature.properties.icon as MarkerIcon;
-  const divHtml = `<i class="fas ${icon.name} fa-2x" style="color: ${icon.color}"></i>`;
-  const ico = divIcon({className: 'leaflet-fa-marker-icon', html: divHtml});
-  return marker(latlng, {icon: ico, ...feature.styles});
-}
-
-function createCustomCircleMarker(latlng: LatLng, options: MarkerOptions): CircleMarker {
-  return circleMarker(latlng, options);
 }

--- a/src/app/utils/leafletUtils.ts
+++ b/src/app/utils/leafletUtils.ts
@@ -1,11 +1,11 @@
-import {CircleMarker, circleMarker, divIcon, LatLng, Marker, marker} from "leaflet";
-import {Feature} from "../models/models";
+import {CircleMarker, MarkerOptions, circleMarker, divIcon, LatLng, Marker, marker} from 'leaflet';
+import {Feature, MarkerConfig, Path, MarkerIcon} from '../models/models';
 
-function createCircleMarker (feature: Feature, latlng: LatLng): CircleMarker {
-  let options = {
+function createCircleMarker(feature: Feature, latlng: LatLng): CircleMarker {
+  const options = {
     radius: 8,
-    fillColor: "#d3d3d3",
-    color: "black",
+    fillColor: '#d3d3d3',
+    color: 'black',
     weight: 1,
     opacity: 1,
     fillOpacity: 0.8
@@ -13,35 +13,51 @@ function createCircleMarker (feature: Feature, latlng: LatLng): CircleMarker {
   return circleMarker( latlng, options );
 }
 
-function createImageMarker (feature: Feature, latlng: LatLng): Marker {
-  let divHtml = "<i class='fas fa-camera-retro fa-2x light-blue'></i>";
-  let ico = divIcon({className: 'leaflet-fa-marker-icon', html: divHtml});
+function createImageMarker(feature: Feature, latlng: LatLng): Marker {
+  const divHtml = '<i class="fas fa-camera-retro fa-2x light-blue"></i>';
+  const ico = divIcon({className: 'leaflet-fa-marker-icon', html: divHtml});
   return marker(latlng, {icon: ico});
 }
 
-function createCollectionMarker (feature: Feature, latlng: LatLng) : Marker {
-  let divHtml = '<i class="fa fa-folder-open fa-2x light-blue"></i>';
-  let ico = divIcon({className: 'icon-marker', html: divHtml});
-  return marker(latlng, {icon: ico});
-}
-function createVideoMarker (feature: Feature, latlng: LatLng): Marker {
-  let divHtml = "<i class='fas fa-video fa-2x light-blue'></i>";
-  let ico = divIcon({className: 'leaflet-fa-marker-icon', html: divHtml});
+function createCollectionMarker(feature: Feature, latlng: LatLng): Marker {
+  const divHtml = '<i class="fa fa-folder-open fa-2x light-blue"></i>';
+  const ico = divIcon({className: 'icon-marker', html: divHtml});
   return marker(latlng, {icon: ico});
 }
 
-export function createMarker(feature: Feature, latlng: LatLng) : Marker {
-  let marker;
-  if (feature.featureType() == 'image') {
-    marker = createImageMarker(feature, latlng);
-  } else if (feature.featureType() == 'collection'){
-    marker =  createCollectionMarker(feature, latlng);
-  } else if (feature.featureType() == 'video') {
-    marker = createVideoMarker(feature, latlng)
+function createVideoMarker(feature: Feature, latlng: LatLng): Marker {
+  const divHtml = '<i class="fas fa-video fa-2x light-blue"></i>';
+  const ico = divIcon({className: 'leaflet-fa-marker-icon', html: divHtml});
+  return marker(latlng, {icon: ico});
+}
+
+export function createMarker(feature: Feature, latlng: LatLng): Path {
+  if (feature.properties.customMarker) {
+    if (feature.properties.customMarker === 'icon') {
+      return createCustomIconMarker(feature, latlng);
+    } else { // 'styled'
+      return createCustomCircleMarker(latlng, feature.styles as MarkerOptions);
+    }
+  } else {
+    if (feature.featureType() === 'image') {
+      return createImageMarker(feature, latlng);
+    } else if (feature.featureType() === 'collection') {
+      return createCollectionMarker(feature, latlng);
+    } else if (feature.featureType() === 'video') {
+      return createVideoMarker(feature, latlng);
+    } else {
+      return createCircleMarker(feature, latlng);
+    }
   }
-  else {
-    marker = createCircleMarker(feature, latlng)
-  }
-  return marker;
+}
 
+function createCustomIconMarker(feature: Feature, latlng: LatLng): Marker {
+  const icon = feature.properties.icon as MarkerIcon;
+  const divHtml = `<i class="fas ${icon.name} fa-2x" style="color: ${icon.color}"></i>`;
+  const ico = divIcon({className: 'leaflet-fa-marker-icon', html: divHtml});
+  return marker(latlng, {icon: ico, ...feature.styles});
+}
+
+function createCustomCircleMarker(latlng: LatLng, options: MarkerOptions): CircleMarker {
+  return circleMarker(latlng, options);
 }


### PR DESCRIPTION
## Overview: ##
Adds ability to detect style properties in a feature and display it on the map.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2006](https://jira.tacc.utexas.edu/browse/DES-2006)

## Summary of Changes: ##
Changed `leafletUtils.ts` to add custom marker creators and changed some lines to remove eslint/tslint warnings.


## Testing Steps: ##
~~1. Try to put something like the below after line 150 in `map.component.ts`~~
~~2. Check that it loads the colors/icon~~
~~3. Also try it without the icon property and change `d.properties.customMarker` to `'styled'`~~
~~4. This should show a circle marker with the style applied to it.~~
Import files under `version 2` from https://www.designsafe-ci.org/data/browser/projects/3676202356334531051-242ac117-0001-012/

## UI Photos:
![Screenshot 2021-06-17 at 17-19-02 HazMapper](https://user-images.githubusercontent.com/9425579/122479122-2f419700-cf90-11eb-9e30-1c4f261087ce.png)

## Notes: ##
