### PR TITLE
Task/DES-1998: Refactor agave listing for maps with project information.

### DIFF
--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -35,6 +35,7 @@ export class ControlBarComponent implements OnInit, OnDestroy {
               ) { }
 
   ngOnInit() {
+    this.projectsService.getProjects();
     this.subscription.add(this.projectsService.loadingActiveProject.subscribe(
       value => this.loadingActiveProject = value));
     this.subscription.add(this.projectsService.loadingActiveProjectFailed.subscribe(value => this.loadingActiveProjectFailed = value));
@@ -47,30 +48,14 @@ export class ControlBarComponent implements OnInit, OnDestroy {
         this.loadingData = (loadingOverlay || loadingPointCloud || loadingFeature);
       }));
 
-    // potential refactor of this if/else block defined in https://jira.tacc.utexas.edu/browse/DES-1998
-    if (this.authService.isLoggedIn()) {
-      this.agaveSystemsService.list();
-
-      this.subscription.add(combineLatest([this.projectsService.activeProject,
-                                           this.agaveSystemsService.projects])
-        .subscribe(([activeProject, dsProjects]) => {
-          if (activeProject) {
-            this.geoDataService.getDataForProject(activeProject.id, this.isPublicView);
-            this.activeProject = this.agaveSystemsService.getDSProjectInformation([activeProject], dsProjects)[0];
-          } else {
-            this.geoDataService.clearData();
-          }
-        }));
-    } else {
-      this.subscription.add(this.projectsService.activeProject.subscribe(next => {
-        this.activeProject = next;
-        if (this.activeProject) {
-          this.geoDataService.getDataForProject(next.id, this.isPublicView);
-        } else {
-          this.geoDataService.clearData();
-        }
-      }));
-    }
+    this.subscription.add(this.projectsService.activeProject.subscribe(activeProject => {
+      if (activeProject) {
+        this.geoDataService.getDataForProject(activeProject.id, this.isPublicView);
+        this.activeProject = activeProject;
+      } else {
+        this.geoDataService.clearData();
+      }
+    }));
 
     this.subscription.add(combineLatest([this.authService.currentUser,
       this.projectsService.projectUsers$])

--- a/src/app/components/file-browser/file-browser.component.ts
+++ b/src/app/components/file-browser/file-browser.component.ts
@@ -39,7 +39,7 @@ export class FileBrowserComponent implements OnInit {
   public firstFileIndex: number;
   public fileDeselectMode: boolean = false;
 
-  public projects: Array<SystemSummary>;
+  public projects: Array<any>;
   private selectedSystem: SystemSummary;
   public myDataSystem: SystemSummary;
   public communityDataSystem: SystemSummary;

--- a/src/app/components/main-welcome/main-welcome.component.ts
+++ b/src/app/components/main-welcome/main-welcome.component.ts
@@ -36,19 +36,17 @@ export class MainWelcomeComponent implements OnInit {
 
   ngOnInit() {
     this.projectsService.getProjects();
-    this.agaveSystemsService.list();
 
     this.projectsService.loadingProjectsFailed.subscribe((notConnected) => {
       this.notConnected = notConnected;
     });
 
-    combineLatest(
-      this.projectsService.projects,
-      this.agaveSystemsService.projects)
-        .subscribe(([projects, dsProjects]) => {
-          this.projects = this.agaveSystemsService.getDSProjectInformation(projects, dsProjects);
-          this.spinner = false;
-        });
+    this.projectsService.projects.subscribe((projects) => {
+      this.projects = projects;
+      if (projects.length > 0) {
+        this.spinner = false;
+      }
+    });
   }
 
   routeToProject(projectUUID: string) {

--- a/src/app/components/users-panel/users-panel.component.ts
+++ b/src/app/components/users-panel/users-panel.component.ts
@@ -39,18 +39,14 @@ export class UsersPanelComponent implements OnInit {
               private envService: EnvService) { }
 
   ngOnInit() {
-    this.agaveSystemsService.list();
-
     this.addUserForm = new FormGroup( {
       username: new FormControl()
     });
 
-    combineLatest([this.projectsService.activeProject,
-                                         this.agaveSystemsService.projects])
-      .subscribe(([activeProject, dsProjects]) => {
+    this.projectsService.activeProject.subscribe(activeProject => {
       if (activeProject) {
+        this.activeProject = activeProject;
         const portalUrl = this.envService.portalUrl + 'data/browser/';
-        this.activeProject = this.agaveSystemsService.getDSProjectInformation([activeProject], dsProjects)[0];
         if (activeProject.system_id) {
           if (activeProject.system_id.startsWith('project')) {
             this.dsHref = portalUrl + 'projects/' +


### PR DESCRIPTION
## Overview: ##
I rewrote parts of the code, in which `agaveSystemsService.list()` and `agaveSystemsService.getDSProjectInformation()` were redundantly used to get a project/map list with DesignSafe project information.

## PR Status: ##

* [ ] Ready.
* [X] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1998](https://jira.tacc.utexas.edu/browse/DES-1998)

## Summary of Changes: ##

## Testing Steps: ##
1. Ensure that `main-welcome`, `control-bar`, `user-panel`, and `file-browser` components all work as usual by displaying the correct project information on maps that are saved to DS projects.
2. Ensure that maps without project association are not affected.

## UI Photos:
N/A

## Notes: ##
I think querying/mapping project information every time might get a bit too expensive if one has many projects. This may affect load time significantly...