### PR TITLE
Add spinner to welcome list item on deletion in progress.

### DIFF
--- a/src/app/components/main-welcome/main-welcome.component.html
+++ b/src/app/components/main-welcome/main-welcome.component.html
@@ -72,7 +72,7 @@
                       <i class="fas fa-edit"></i>
                     </button>
                     <ng-container *ngIf="p.deletingFailed; else deletingNotFailed">
-                      <button style="color: #cc4b37" class="project-list-item-button" [tooltip]="'Map Failed to Delete'">
+                      <button style="color: #cc4b37" class="project-list-item-button" [tooltip]="'Map Failed to Delete'" (click)="openDeleteProjectModal(p, $event)">
                         <i class="fas fa-exclamation-triangle"></i>
                       </button>
                     </ng-container>

--- a/src/app/components/main-welcome/main-welcome.component.html
+++ b/src/app/components/main-welcome/main-welcome.component.html
@@ -71,9 +71,25 @@
                     <button class="project-list-item-button" [tooltip]="'Edit Map'">
                       <i class="fas fa-edit"></i>
                     </button>
-                    <button class="project-list-item-button" [tooltip]="'Delete Map'" (click)="openDeleteProjectModal(p, $event)">
-                      <i class="fas fa-trash"></i>
-                    </button>
+                    <ng-container *ngIf="p.deletingFailed; else deletingNotFailed">
+                      <button style="color: #cc4b37" class="project-list-item-button" [tooltip]="'Map Failed to Delete'">
+                        <i class="fas fa-exclamation-triangle"></i>
+                      </button>
+                    </ng-container>
+                    <ng-template #deletingNotFailed>
+                      <ng-container *ngIf="p.deleting; else notDeleting">
+                        <button class="project-list-item-button" [tooltip]="'Deleting Map'">
+                          <i class="fas fa-spin fa-spinner"></i>
+                        </button>
+                      </ng-container>
+
+                      <ng-template #notDeleting>
+                        <button class="project-list-item-button" [tooltip]="'Delete Map'" (click)="openDeleteProjectModal(p, $event)">
+                          <i class="fas fa-trash"></i>
+                        </button>
+                      </ng-template>
+                    </ng-template>
+
                   </div>
                 </div>
               </div>

--- a/src/app/models/models.ts
+++ b/src/app/models/models.ts
@@ -58,6 +58,8 @@ export interface Project {
   system_file?: string;
   system_id?: string;
   system_path?: string;
+  deleting?: boolean;
+  deletingFailed?: boolean;
 }
 
 export class Project implements Project {

--- a/src/app/services/projects.service.ts
+++ b/src/app/services/projects.service.ts
@@ -34,6 +34,9 @@ export class ProjectsService {
   private _loadingActiveProjectFailed: BehaviorSubject<boolean> = new BehaviorSubject(false);
   public loadingActiveProjectFailed: Observable<boolean> = this._loadingActiveProjectFailed.asObservable();
 
+  private _deletingProjects: BehaviorSubject<Project[]> = new BehaviorSubject<Project[]>([]);
+  public deletingProjects: Observable<Project[]> = this._deletingProjects.asObservable();
+
   constructor(private http: HttpClient,
               private notificationsService: NotificationsService,
               private geoDataService: GeoDataService,
@@ -42,15 +45,32 @@ export class ProjectsService {
               private authService: AuthService,
               private envService: EnvService) { }
 
+  updateProjectsList(resp: Project[] = []) {
+    const myProjs = resp.length !== 0
+      ? resp
+      : this._projects.value;
+
+    this._deletingProjects.value.length !== 0
+      ? this._projects.next(myProjs.map(p => {
+        const deletingProj = this._deletingProjects.value.find(dp => dp.id === p.id);
+        return deletingProj
+          ? deletingProj
+          : p;
+      }))
+      : this._projects.next(myProjs);
+  }
+
   getProjects(): void {
     this._loadingProjectsFailed.next(false);
     this.http.get<Project[]>(this.envService.apiUrl + `/projects/`).subscribe( resp => {
-      this._projects.next(resp);
+
+      this.updateProjectsList(resp);
+
       this._loadingProjectsFailed.next(false);
     }, error => {
       this._loadingProjectsFailed.next(true);
       this.notificationsService.showErrorToast('Failed to retrieve project data! Geoapi might be down.');
-      });
+    });
   }
 
   // TODO: Utilize project metdata
@@ -148,10 +168,8 @@ export class ProjectsService {
                                                      AgaveFileOperations.Delete);
     }
 
-    this._projects.next(this._projects.value.map(p =>
-      p.id === proj.id
-      ? {...p, deleting: true}
-      : p));
+    this._deletingProjects.next([...this._deletingProjects.value, {...proj, deleting: true}]);
+    this.updateProjectsList();
 
     this.router.navigate([MAIN]);
 
@@ -160,12 +178,20 @@ export class ProjectsService {
         if (proj.system_path) {
           this.agaveSystemsService.deleteFile(proj);
         }
+
+        this._deletingProjects.next(this._deletingProjects.value.filter(p => p.id !== proj.id));
+        this.updateProjectsList();
         this.getProjects();
       }, error => {
-        this._projects.next(this._projects.value.map(p =>
-          p.id === proj.id
-          ? {...p, deletingFailed: true}
-          : p));
+
+        this._deletingProjects.next(this._deletingProjects.value.map(p => {
+          return p.id === proj.id
+            ? {...p, deleting: false, deletingFailed: true}
+            : p;
+        }));
+        this.updateProjectsList();
+
+        this.getProjects();
 
         this.notificationsService.showErrorToast('Could not delete project!');
         console.error(error);

--- a/src/app/services/projects.service.ts
+++ b/src/app/services/projects.service.ts
@@ -148,14 +148,25 @@ export class ProjectsService {
                                                      AgaveFileOperations.Delete);
     }
 
+    this._projects.next(this._projects.value.map(p =>
+      p.id === proj.id
+      ? {...p, deleting: true}
+      : p));
+
+    this.router.navigate([MAIN]);
+
     this.http.delete(this.envService.apiUrl + `/projects/${proj.id}/`)
       .subscribe((resp) => {
         if (proj.system_path) {
           this.agaveSystemsService.deleteFile(proj);
         }
         this.getProjects();
-        this.router.navigate([MAIN]);
       }, error => {
+        this._projects.next(this._projects.value.map(p =>
+          p.id === proj.id
+          ? {...p, deletingFailed: true}
+          : p));
+
         this.notificationsService.showErrorToast('Could not delete project!');
         console.error(error);
       });


### PR DESCRIPTION
## Overview: ##
Adds a spinner notification when deleting maps to indicate progress.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2165](https://jira.tacc.utexas.edu/browse/DES-2165)

## Summary of Changes: ##
Now when deleting a map, we redirect to the welcome page first and then show the spinner to wait on the deletion of the map.

## Testing Steps: ##
1. Try deleting a map with many assets. Or maybe insert `sleep()` in the geoapi project delete endpoint.
2. When deleting from the "Manage Panel", ensure that you are redirected to the "Welcome" page.
3. Ensure that you see a spinner before the project is deleted.
4. Repeat steps 2-3 for deleting the project from the "Welcome" page.
5. Ensure that error status is shown when error is given (raise ApiException from the geoapi project delete endpoint).
6. Ensure that the error status is shown in the welcome page.

## UI Photos:
![Screenshot from 2022-01-31 14-12-00](https://user-images.githubusercontent.com/9425579/151879049-fe0cef4f-9f3f-4281-bab5-d7731c548e6e.png)
![Screenshot from 2022-01-31 15-49-02](https://user-images.githubusercontent.com/9425579/151879095-d3f532f3-648c-4363-90d9-a9fd4927aca6.png)

## Notes: ##
