### PR TITLE
Bug/DES-2167: Associated project is not shown with map

### DIFF
--- a/src/app/components/main-welcome/main-welcome.component.html
+++ b/src/app/components/main-welcome/main-welcome.component.html
@@ -58,7 +58,7 @@
                   </div>
 
                   <div class="project-column">
-                    <ng-container *ngIf="p.system_path && p.system_id.startsWith('project'); else noProject" class="list-column link-hover">
+                    <ng-container *ngIf="p.system_id.startsWith('project'); else noProject" class="list-column link-hover">
                       <span class="project-name" [tooltip]="p.title">
                         {{p.ds_id}} | {{p.title}}
                       </span>

--- a/src/app/components/modal-create-project/modal-create-project.component.html
+++ b/src/app/components/modal-create-project/modal-create-project.component.html
@@ -22,7 +22,7 @@
 
         <div style="padding: 20px 0px">
           <label> Save Location:
-            <span style="color: #007cb6">{{selectedFiles.length > 0 ? selectedFiles[0].path : currentPath}}</span>
+            <span style="color: #007cb6">{{selectedFiles.length > 0 ? (selectedFiles[0].path || '/') : (currentPath || '/')}}</span>
           </label>
         </div>
 

--- a/src/app/components/modal-create-project/modal-create-project.component.ts
+++ b/src/app/components/modal-create-project/modal-create-project.component.ts
@@ -73,7 +73,10 @@ export class ModalCreateProjectComponent implements OnInit, AfterContentChecked 
 
     p.description = this.projCreateForm.get('description').value;
     p.name = this.projCreateForm.get('name').value;
-    p.system_path = this.selectedFiles.length > 0 ? this.selectedFiles[0].path : this.currentPath;
+    p.system_path = this.selectedFiles.length > 0 ?
+      (this.selectedFiles[0].path || '/') :
+      (this.currentPath || '/')
+
     p.system_id = this.selectedSystem.id;
     p.system_file = this.projCreateForm.get('fileName').value
       ? this.projCreateForm.get('fileName').value

--- a/src/app/services/projects.service.ts
+++ b/src/app/services/projects.service.ts
@@ -175,7 +175,7 @@ export class ProjectsService {
 
     this.http.delete(this.envService.apiUrl + `/projects/${proj.id}/`)
       .subscribe((resp) => {
-        if (proj.system_path) {
+        if (proj.system_path || proj.ds_id) {
           this.agaveSystemsService.deleteFile(proj);
         }
 


### PR DESCRIPTION
## Overview: ##
When selecting `..` from a single level below the root path of a system (i.e. a from a folder in root), the `system_path` would be an empty string.
Furthermore, the welcome page was checking against the existence of `system_path`, where it just needed to check that it is a project system.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2167](https://jira.tacc.utexas.edu/browse/DES-2167)

## Summary of Changes: ##
1. Changed the `system_path` to revert to root path `'/'` if the selected path is empty.

## Testing Steps: ##
1. Set the `AppEnvironment` `backend` to `EnvironmentType.Production` in `environment.ts`.
2. Ensure that the **GEER_Marshall Fire, Colorado** project correctly shows the project information in the welcome page.
3. Ensure that, when creating a project, the page selecting the `..` from a inside a folder located in the root path gives you a `/` for the root path instead of an empty string (this should be indicated in the modal next to **Save Location:**).

## UI Photos:
![Screenshot from 2022-02-02 12-02-12](https://user-images.githubusercontent.com/9425579/152222646-6129c35e-511a-4f1b-bfc4-0780ccdecf6c.png)


## Notes: ##
