### PR TITLE
Fix systemId rendering bug.

### DIFF
--- a/src/app/components/main-welcome/main-welcome.component.html
+++ b/src/app/components/main-welcome/main-welcome.component.html
@@ -58,7 +58,7 @@
                   </div>
 
                   <div class="project-column">
-                    <ng-container *ngIf="p.system_id.startsWith('project'); else noProject" class="list-column link-hover">
+                    <ng-container *ngIf="p.system_id && p.system_id.startsWith('project'); else noProject" class="list-column link-hover">
                       <span class="project-name" [tooltip]="p.title">
                         {{p.ds_id}} | {{p.title}}
                       </span>

--- a/src/app/services/projects.service.ts
+++ b/src/app/services/projects.service.ts
@@ -110,7 +110,7 @@ export class ProjectsService {
             this.agaveSystemsService.saveFile(proj);
           }
 
-          if (proj.system_id.startsWith('project')) {
+          if (proj.system_id && proj.system_id.startsWith('project')) {
             this.agaveSystemsService.updateProjectMetadata(proj,
                                                            AgaveFileOperations.Update);
           }


### PR DESCRIPTION
## Overview: ##
There is an error when trying to render older projects in the `welcome-page` component.
Older projects do not have a `systemId`. So this adds a check to that.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##
N/A

## Summary of Changes: ##

## Testing Steps: ##
1. Ensure that you do not have an error when you have older projects on your welcome page projects list.

## UI Photos:

## Notes: ##
