### PR TITLE
Task/DES-2183: Add ArcGIS tile layer support to hazmapper.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,13 @@
         "@angular/platform-browser-dynamic": "~8.2.5",
         "@angular/router": "~8.2.5",
         "@turf/turf": "^5.1.6",
+        "@types/esri-leaflet": "^2.1.9",
         "@types/geojson": "^7946.0.6",
         "@types/leaflet": "^1.4.3",
         "@types/leaflet.markercluster": "^1.0.3",
         "@types/node": "^13.1.7",
         "core-js": "^2.5.4",
+        "esri-leaflet": "^3.0.4",
         "foundation-sites": "^6.5.3",
         "hammerjs": "^2.0.8",
         "leaflet": "^1.4.0",
@@ -857,6 +859,19 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+    },
+    "node_modules/@terraformer/arcgis": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@terraformer/arcgis/-/arcgis-2.1.0.tgz",
+      "integrity": "sha512-eKTvNXze2Fo7vAEjvJFIGn5QdU0OP4aD9DuT/uTBLRM1QS+ju7KtPITbVW+xgCviHLnOVeFQ1UsIs9kjkakD4g==",
+      "dependencies": {
+        "@terraformer/common": "^2.0.7"
+      }
+    },
+    "node_modules/@terraformer/common": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@terraformer/common/-/common-2.0.7.tgz",
+      "integrity": "sha512-8bl+/JT0Rw6FYe2H3FfJS8uQwgzGl+UHs+8JX0TQLHgA4sMDEwObbMwo0iP3FVONwPXrPHEpC5YH7Grve0cl9A=="
     },
     "node_modules/@turf/along": {
       "version": "5.1.5",
@@ -2144,6 +2159,14 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.2.tgz",
       "integrity": "sha512-8V2aCcPM3WLuJvJpF6N60uUvdZb7NHjpjQlLk1QmZbTP4XZET/FX0c3TJ3K7qt4L98FS1Pifa8BVofTVuJFWVA=="
+    },
+    "node_modules/@types/esri-leaflet": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@types/esri-leaflet/-/esri-leaflet-2.1.9.tgz",
+      "integrity": "sha512-Z3GLyJTepEsEpo2FB3eRqSRxGw1Y2Vohpuu5Qp87tc3MGbXjhSUTRYldoaACZj6JQQJuOnyK9FLMdSziq5C1Ow==",
+      "dependencies": {
+        "@types/leaflet": "*"
+      }
     },
     "node_modules/@types/events": {
       "version": "3.0.0",
@@ -5085,6 +5108,18 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/esri-leaflet": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-3.0.4.tgz",
+      "integrity": "sha512-K/nnrlu9DUptYWQtBxGRVCFxJA8GSSyw6KNH/onxQ7jmuKMoS3rzV6kAntFv5bF/Iued3hqRXxbPnQD7oDcrAg==",
+      "dependencies": {
+        "@terraformer/arcgis": "^2.0.7",
+        "tiny-binary-search": "^1.0.3"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.0.0"
       }
     },
     "node_modules/estraverse": {
@@ -12218,6 +12253,11 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/tiny-binary-search": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-binary-search/-/tiny-binary-search-1.0.3.tgz",
+      "integrity": "sha512-STSHX/L5nI9WTLv6wrzJbAPbO7OIISX83KFBh2GVbX1Uz/vgZOU/ANn/8iV6t35yMTpoPzzO+3OQid3mifE0CA=="
+    },
     "node_modules/tinyqueue": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
@@ -14103,6 +14143,19 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
     },
+    "@terraformer/arcgis": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@terraformer/arcgis/-/arcgis-2.1.0.tgz",
+      "integrity": "sha512-eKTvNXze2Fo7vAEjvJFIGn5QdU0OP4aD9DuT/uTBLRM1QS+ju7KtPITbVW+xgCviHLnOVeFQ1UsIs9kjkakD4g==",
+      "requires": {
+        "@terraformer/common": "^2.0.7"
+      }
+    },
+    "@terraformer/common": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@terraformer/common/-/common-2.0.7.tgz",
+      "integrity": "sha512-8bl+/JT0Rw6FYe2H3FfJS8uQwgzGl+UHs+8JX0TQLHgA4sMDEwObbMwo0iP3FVONwPXrPHEpC5YH7Grve0cl9A=="
+    },
     "@turf/along": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
@@ -15393,6 +15446,14 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.2.tgz",
       "integrity": "sha512-8V2aCcPM3WLuJvJpF6N60uUvdZb7NHjpjQlLk1QmZbTP4XZET/FX0c3TJ3K7qt4L98FS1Pifa8BVofTVuJFWVA=="
+    },
+    "@types/esri-leaflet": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@types/esri-leaflet/-/esri-leaflet-2.1.9.tgz",
+      "integrity": "sha512-Z3GLyJTepEsEpo2FB3eRqSRxGw1Y2Vohpuu5Qp87tc3MGbXjhSUTRYldoaACZj6JQQJuOnyK9FLMdSziq5C1Ow==",
+      "requires": {
+        "@types/leaflet": "*"
+      }
     },
     "@types/events": {
       "version": "3.0.0",
@@ -17971,6 +18032,15 @@
       "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
+      }
+    },
+    "esri-leaflet": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-3.0.4.tgz",
+      "integrity": "sha512-K/nnrlu9DUptYWQtBxGRVCFxJA8GSSyw6KNH/onxQ7jmuKMoS3rzV6kAntFv5bF/Iued3hqRXxbPnQD7oDcrAg==",
+      "requires": {
+        "@terraformer/arcgis": "^2.0.7",
+        "tiny-binary-search": "^1.0.3"
       }
     },
     "estraverse": {
@@ -23987,6 +24057,11 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
+    },
+    "tiny-binary-search": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-binary-search/-/tiny-binary-search-1.0.3.tgz",
+      "integrity": "sha512-STSHX/L5nI9WTLv6wrzJbAPbO7OIISX83KFBh2GVbX1Uz/vgZOU/ANn/8iV6t35yMTpoPzzO+3OQid3mifE0CA=="
     },
     "tinyqueue": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
     "@angular/platform-browser-dynamic": "~8.2.5",
     "@angular/router": "~8.2.5",
     "@turf/turf": "^5.1.6",
+    "@types/esri-leaflet": "^2.1.9",
     "@types/geojson": "^7946.0.6",
     "@types/leaflet": "^1.4.3",
     "@types/leaflet.markercluster": "^1.0.3",
     "@types/node": "^13.1.7",
     "core-js": "^2.5.4",
+    "esri-leaflet": "^3.0.4",
     "foundation-sites": "^6.5.3",
     "hammerjs": "^2.0.8",
     "leaflet": "^1.4.0",
@@ -61,10 +63,10 @@
     "ngx-foundation": "^1.0.8",
     "ngx-infinite-scroll": "^8.0.0",
     "protractor": "~5.4.0",
+    "querystring": "^0.2.0",
     "ts-mockito": "^2.4.2",
     "ts-node": "~7.0.0",
     "tslint": "~5.11.0",
-    "typescript": "~3.5.3",
-    "querystring": "^0.2.0"
+    "typescript": "~3.5.3"
   }
 }

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import * as L from 'leaflet';
+import * as esri from 'esri-leaflet';
 import 'types.leaflet.heat';
 import 'leaflet.markercluster';
 
@@ -125,6 +126,10 @@ export class MapComponent implements OnInit, OnDestroy {
       return L.tileLayer(ts.url, layerOptions);
     } else if (ts.type === 'wms') {
       return L.tileLayer.wms(ts.url, layerOptions);
+    } else if (ts.type === 'arcgis') {
+      return esri.tiledMapLayer({
+        url: ts.url
+      });
     }
   }
 

--- a/src/app/components/modal-create-tile-server/modal-create-tile-server.component.html
+++ b/src/app/components/modal-create-tile-server/modal-create-tile-server.component.html
@@ -32,6 +32,7 @@
       <select formControlName="type" required="true">
         <option value="tms">TMS</option>
         <option value="wms">WMS</option>
+        <option value="arcgis">ArcGIS</option>
       </select>
     </label>
     <label> Name:
@@ -48,7 +49,7 @@
              required="true">
     </label>
 
-    <div class="grid-x grid-margin-x">
+    <div *ngIf="tsCreateForm.get('type').value == 'tms' || tsCreateForm.get('type').value == 'wms'" class="grid-x grid-margin-x">
       <div class="small-6 cell">
         <label> Attribution:
           <input type="text"


### PR DESCRIPTION
## Overview: ##
Adds ArcGIS tile layer support to hazmapper.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2183](https://jira.tacc.utexas.edu/browse/DES-2183)

## Summary of Changes: ##
Added `esri-leaflet` and `@types/esri-leaflet` and hooked them up to the tile layer system.

## Testing Steps: ##
1. Go to "Layers"
2. Click "+" to add a layer
3. Select "Manual" as the "Import Method"
4. Select  "ArcGIS" as the "Server Type"
5. Give it an arbitrary "Name"
6. Apply following urls
 - https://services.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer (A basemap)
 - https://tiles.arcgis.com/tiles/JL4BwWcjcPuWhBm9/arcgis/rest/services/RPD1085_Map/MapServer (Colorado data: This will be around Louisville, Colorado, it's really hard to find it. you might want to keep just the "Road" basemap displayed).
7. Ensure that they show up and interact correctly with other layers.

## UI Photos:
![Screenshot from 2022-02-11 11-55-34](https://user-images.githubusercontent.com/9425579/153643853-32d9fd49-c05c-4f9d-9639-87de71b5694e.png)

## Notes: ##
There is no method of "zooming-in" to specific layers...
There might be more information available through the arcgis server.
However, I wasn't sure how to generalize that interface with the already existing basemap layers.
At the moment, I'm assuming that they would have assets around that location.