### PR TITLE
Bug/DES-2185: Fix filtering query.

### DIFF
--- a/src/app/components/filters-panel/filters-panel.component.html
+++ b/src/app/components/filters-panel/filters-panel.component.html
@@ -13,7 +13,7 @@
             <h6>Asset Types</h6>
             <div *ngFor="let ft of featureTypes">
                 <label htmlFor="{{featureTypeLabels[ft]}}Filter">
-                    <input type="checkbox" [id]="featureTypeLabels[ft] +'Filter'" [checked]="assetFilters.assetType === ft"  (change)="updateAssetTypeFilters(ft)">
+                    <input type="checkbox" [id]="featureTypeLabels[ft] +'Filter'" [checked]="enabledFilters.includes(ft)"  (change)="updateAssetTypeFilters(ft)">
                     {{featureTypeLabels[ft]}}
                 </label>
             </div>

--- a/src/app/components/filters-panel/filters-panel.component.html
+++ b/src/app/components/filters-panel/filters-panel.component.html
@@ -13,7 +13,7 @@
             <h6>Asset Types</h6>
             <div *ngFor="let ft of featureTypes">
                 <label htmlFor="{{featureTypeLabels[ft]}}Filter">
-                    <input type="checkbox" [id]="featureTypeLabels[ft] +'Filter'" [checked]="enabledFilters.includes(ft)"  (change)="updateAssetTypeFilters(ft)">
+                    <input type="checkbox" [id]="featureTypeLabels[ft] +'Filter'" [disabled]="enabledFilters.length < 2 && enabledFilters.includes(ft)" [checked]="enabledFilters.includes(ft)"  (change)="updateAssetTypeFilters(ft)">
                     {{featureTypeLabels[ft]}}
                 </label>
             </div>

--- a/src/app/components/filters-panel/filters-panel.component.ts
+++ b/src/app/components/filters-panel/filters-panel.component.ts
@@ -18,19 +18,26 @@ export class FiltersPanelComponent implements OnInit {
   readonly featureTypes = featureTypes;
   readonly featureTypeLabels = featureTypeLabels;
 
+  enabledFilters: Array<string>;
+
   constructor(private filterService: FilterService, private geoDataService: GeoDataService, private projectsService: ProjectsService) { }
 
   ngOnInit() {
     this.filterService.assetFilter.subscribe( (next) => {
       this.assetFilters = next;
     });
+
+    this.filterService.enabledAssetTypes.subscribe( (next) => {
+      this.enabledFilters = next;
+    });
+
     this.projectsService.activeProject.subscribe( (next) => {
       this.activeProject = next;
     });
   }
 
   updateAssetTypeFilters(ftype: string): void {
-    this.filterService.updateAssetTypes(ftype);
+    this.filterService.updateEnabledAssetTypes(ftype);
     this.geoDataService.getFeatures(this.activeProject.id, false);
   }
 }

--- a/src/app/constants/assets.ts
+++ b/src/app/constants/assets.ts
@@ -1,9 +1,10 @@
-export const featureTypes = ['image', 'video', 'point_cloud'] as const;
+export const featureTypes = ['image', 'video', 'point_cloud', 'no_asset_vector'] as const;
 
 type featuresTypeID = typeof featureTypes[number];
 
 export const featureTypeLabels: Record<featuresTypeID, string> = {
   image: 'Images',
   video: 'Videos',
-  point_cloud: 'Point Clouds'
+  point_cloud: 'Point Clouds',
+  no_asset_vector: 'No Asset Vector'
 } as const;

--- a/src/app/models/models.ts
+++ b/src/app/models/models.ts
@@ -37,6 +37,10 @@ export class AssetFilters {
   bbox: Array<number> = [];
   assetType = '';
 
+  constructor(assetType: string) {
+    this.assetType = assetType;
+  }
+
   toJson() {
     return {
       assetType: this.assetType,

--- a/src/app/models/models.ts
+++ b/src/app/models/models.ts
@@ -37,7 +37,7 @@ export class AssetFilters {
   bbox: Array<number> = [];
   assetType = '';
 
-  constructor(assetType: string) {
+  constructor(assetType?: string) {
     this.assetType = assetType;
   }
 

--- a/src/app/services/filter.service.ts
+++ b/src/app/services/filter.service.ts
@@ -1,23 +1,39 @@
 import { Injectable } from '@angular/core';
 import {AssetFilters, Project} from '../models/models';
 import {BehaviorSubject, Observable} from "rxjs";
+import {featureTypes, featureTypeLabels} from '../constants/assets';
 
 @Injectable({
   providedIn: 'root'
 })
 
 export class FilterService {
-  private readonly _assetFilter: BehaviorSubject<AssetFilters> = new BehaviorSubject(new AssetFilters);
+  private readonly _assetFilter: BehaviorSubject<AssetFilters> = new BehaviorSubject(new AssetFilters(featureTypes.join(',')));
   public readonly assetFilter: Observable<AssetFilters> = this._assetFilter.asObservable();
+
+  private _enabledAssetTypes: BehaviorSubject<Array<string>> = new BehaviorSubject([...featureTypes]);
+  public enabledAssetTypes: Observable<Array<string>> = this._enabledAssetTypes.asObservable();
 
   setAssetFilter(val: AssetFilters) {
     this._assetFilter.next(val);
   }
 
-  updateAssetTypes(assetType: string) {
+  updateAssetTypes() {
+    const flatAssetTypes = this._enabledAssetTypes.getValue().join(',');
     let updatedAssetFilter = this._assetFilter.getValue();
-    updatedAssetFilter.assetType = updatedAssetFilter.assetType===assetType ? "": assetType;
+    updatedAssetFilter.assetType = updatedAssetFilter.assetType === flatAssetTypes ? "" : flatAssetTypes;
     this.setAssetFilter(updatedAssetFilter);
+  }
+
+  updateEnabledAssetTypes(assetType: string) {
+    let enabledAssetTypes = this._enabledAssetTypes.getValue();
+
+    if (enabledAssetTypes.includes(assetType)) {
+      this._enabledAssetTypes.next(enabledAssetTypes.filter(at => at !== assetType));
+    } else {
+      this._enabledAssetTypes.next([...enabledAssetTypes, assetType]);
+    }
+    this.updateAssetTypes();
   }
 
   updateBBox(bbox: Array<number>): void {


### PR DESCRIPTION
## Overview: ##
Change asset filter interface so that all filter types are initially selected (checkbox behavior rather than radio, see image).

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2185](https://jira.tacc.utexas.edu/browse/DES-2185)

## Summary of Changes: ##
Added an `enabledAssetTypes` array in the `filters-service` and changed the query to the server to be a comma separated string.

## Testing Steps: ##
1. Test with TACC-Cloud/geoapi#76
2. Ensure that, on initial load, the assets are all displayed correctly.
3. Ensure that each asset type is filtered out when unselected.

## UI Photos:
![Screenshot from 2022-02-21 16-45-59](https://user-images.githubusercontent.com/9425579/155034823-0167d016-0943-4c45-b060-c28ab426741c.png)

## Notes: ##
