### PR TITLE
Bug/DES-2215: Adjust tile server zoom levels

### DIFF
--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -86,7 +86,7 @@ export class MapComponent implements OnInit, OnDestroy {
     this.map = new L.Map('map', {
       center: [40, -80],
       zoom: 3,
-      maxZoom: 19,
+      maxZoom: 24,
     });
 
     this.subscription.add(
@@ -360,6 +360,7 @@ export class MapComponent implements OnInit, OnDestroy {
     } else if (ts.type === 'arcgis') {
       return esri.tiledMapLayer({
         url: ts.url,
+        maxZoom: 24
       });
     }
   }

--- a/src/app/constants/tile-servers.ts
+++ b/src/app/constants/tile-servers.ts
@@ -14,7 +14,8 @@ export const defaultTileServers: ReadonlyArray<TileServer> = [
     },
     tileOptions: {
       minZoom: 0,
-      maxZoom: 19
+      maxZoom: 24,
+      maxNativeZoom: 19
     },
   },
   {
@@ -30,7 +31,8 @@ export const defaultTileServers: ReadonlyArray<TileServer> = [
     },
     tileOptions: {
       minZoom: 0,
-      maxZoom: 19
+      maxZoom: 24,
+      maxNativeZoom: 19
     },
   }
 ] as const;

--- a/src/app/models/models.ts
+++ b/src/app/models/models.ts
@@ -153,6 +153,7 @@ interface TileServerOptions {
   // TMS options
   minZoom?: number;
   maxZoom?: number;
+  maxNativeZoom?: number;
 
   // WMS options
   layers?: string;


### PR DESCRIPTION
## Overview: ##
Allow users to zoom further in tms tiles and arcgis tiles.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2215](https://jira.tacc.utexas.edu/browse/DES-2215)

## Summary of Changes: ##
Set `maxNativeZoom` and `maxZoom` to allow users to zoom further than before.

## Testing Steps: ##
1. Try testing with https://tiles.arcgis.com/tiles/JL4BwWcjcPuWhBm9/arcgis/rest/services/RPD1085_Map/MapServer
2. Ensure that the map doesn't disappear after zooming beyond zoom level 19.

## UI Photos:
![Screenshot from 2022-02-21 16-45-59](https://user-images.githubusercontent.com/9425579/170073395-05c3af9e-67c5-4a88-bbe1-bd4e70bf0caa.png)

## Notes: ##
