### PR TITLE
Bug/DES-2273: Mapillary authentication token enforce login

### DIFF
--- a/src/app/components/dock/dock.component.html
+++ b/src/app/components/dock/dock.component.html
@@ -40,7 +40,7 @@
         </div>
       </button>
     </div>
-    <div class="dock-button" [ngClass]="{'active': panelsDisplay.streetview}" *ngIf="!isPublicView">
+    <div class="dock-button" [ngClass]="{'active': panelsDisplay.streetview}">
       <button (click)="showPanel('streetview')"  [disabled]="!activeProject">
         <div>
           <img class="dock-button-icon" src="assets/streetview.png" width="32px">
@@ -69,7 +69,7 @@
     <app-measure-panel *ngIf="panelsDisplay.measure" ></app-measure-panel>
     <app-settings-panel *ngIf="panelsDisplay.settings" ></app-settings-panel>
     <app-point-clouds-panel *ngIf="panelsDisplay.pointClouds"></app-point-clouds-panel>
-    <app-streetview-panel *ngIf="panelsDisplay.streetview && !isPublicView"></app-streetview-panel>
+    <app-streetview-panel *ngIf="panelsDisplay.streetview" [isPublicView]=isPublicView></app-streetview-panel>
     <app-users-panel *ngIf="panelsDisplay.users && !isPublicView"></app-users-panel>
     <app-public-map-info-panel *ngIf="panelsDisplay.users && isPublicView"></app-public-map-info-panel>
   </div>

--- a/src/app/components/main-project/main-project.component.html
+++ b/src/app/components/main-project/main-project.component.html
@@ -9,7 +9,7 @@
    <app-dock [isPublicView]=isPublicView></app-dock>
   </div>
   <div class="cell auto">
-    <app-map></app-map>
+    <app-map [isPublicView]=isPublicView></app-map>
   </div>
   <app-asset-detail *ngIf="activeFeature" [isPublicView]=isPublicView></app-asset-detail>
   <app-streetview-asset-detail *ngIf="activeStreetviewAsset"></app-streetview-asset-detail>

--- a/src/app/components/streetview-accounts/streetview-accounts.component.ts
+++ b/src/app/components/streetview-accounts/streetview-accounts.component.ts
@@ -56,7 +56,7 @@ export class StreetviewAccountsComponent implements OnInit {
   }
 
   login(service: string) {
-    this.streetviewAuthenticationService.login(service, this.activeProject.id);
+    this.streetviewAuthenticationService.login(service, this.activeProject.id, false);
   }
 
   logout(service: string) {

--- a/src/app/components/streetview-panel/streetview-panel.component.html
+++ b/src/app/components/streetview-panel/streetview-panel.component.html
@@ -5,48 +5,65 @@
 
   <div class="dock-panel-content">
     <div *ngIf="isLoggedIn('mapillary'); else notAuthenticated">
-      <div *ngIf="activeStreetview && activeStreetview.service_user && activeStreetview.organizations.length; else noUsername">
-        <div class="text-center" style="padding-top: 20px">
-          <label class="tile-server-visibility">
-            Display Mapillary Sequences
-            <input name=""
-              type="checkbox"
-              [checked]="displayStreetview"
-              (change)="toggleStreetviewDisplay()"/>
-          </label>
+      <div *ngIf="!isPublicView; else publicView">
+        <div *ngIf="activeStreetview && activeStreetview.service_user && activeStreetview.organizations.length; else noUsername">
+          <div class="text-center" style="padding-top: 20px">
+            <label class="tile-server-visibility">
+              Display Mapillary Sequences
+              <input name=""
+                type="checkbox"
+                [checked]="displayStreetview"
+                (change)="toggleStreetviewDisplay()"/>
+            </label>
+          </div>
+          <div class="publish-container grid-x align-right">
+            <a class="publish-button" (click)="openStreetviewPublishModal()">
+              <small>
+                <i class="fas fa-plus"></i>
+                Publish
+              </small>
+            </a>
+          </div>
+
+          <tabset>
+            <tab heading="Assets">
+              <app-streetview-assets>
+              </app-streetview-assets>
+            </tab>
+
+            <tab heading="Log">
+              <app-streetview-logs>
+              </app-streetview-logs>
+            </tab>
+
+            <tab heading="Filters">
+              <app-streetview-filters>
+              </app-streetview-filters>
+            </tab>
+
+            <tab heading="Account">
+              <app-streetview-accounts>
+              </app-streetview-accounts>
+            </tab>
+          </tabset>
         </div>
-        <div class="publish-container grid-x align-right">
-          <a class="publish-button" (click)="openStreetviewPublishModal()">
-            <small>
-              <i class="fas fa-plus"></i>
-              Publish
-            </small>
-          </a>
-        </div>
-
-        <tabset>
-        <tab heading="Assets">
-        <app-streetview-assets>
-        </app-streetview-assets>
-        </tab>
-
-        <tab heading="Log">
-        <app-streetview-logs>
-        </app-streetview-logs>
-        </tab>
-
-        <tab heading="Filters">
-        <app-streetview-filters>
-        </app-streetview-filters>
-        </tab>
-
-        <tab heading="Account">
-        <app-streetview-accounts>
-        </app-streetview-accounts>
-        </tab>
-        </tabset>
       </div>
     </div>
+
+    <ng-template #publicView>
+      <div style="text-align: center">
+        <div class="grid-y align-center">
+          <div>
+            Logged into Mapillary
+          </div>
+
+          <button class="button auth-button" (click)="logout('mapillary')">
+            Logout
+          </button>
+
+        </div>
+      </div>
+    </ng-template>
 
     <ng-template #notAuthenticated>
       <div style="margin-top: 8rem; height:100%" class="not-authenticated grid-y align-start text-center">

--- a/src/app/components/streetview-panel/streetview-panel.component.ts
+++ b/src/app/components/streetview-panel/streetview-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { BsModalRef, BsModalService } from 'ngx-foundation';
 import { Streetview } from '../../models/streetview';
 import { StreetviewService } from '../../services/streetview.service';
@@ -16,6 +16,7 @@ import { Project } from 'src/app/models/models';
   styleUrls: ['./streetview-panel.component.styl'],
 })
 export class StreetviewPanelComponent implements OnInit {
+  @Input() isPublicView;
   private activeStreetview: Streetview;
   private activeProject: Project;
   private displayStreetview = false;
@@ -73,7 +74,7 @@ export class StreetviewPanelComponent implements OnInit {
   }
 
   login(svService: string) {
-    this.streetviewAuthenticationService.login(svService, this.activeProject.id);
+    this.streetviewAuthenticationService.login(svService, this.activeProject.id, this.isPublicView);
   }
 
   logout(svService: string) {
@@ -81,7 +82,7 @@ export class StreetviewPanelComponent implements OnInit {
   }
 
   isLoggedIn(svService: string) {
-    return this.streetviewAuthenticationService.isLoggedIn(svService);
+    return this.streetviewAuthenticationService.isLoggedIn(svService, this.isPublicView);
   }
 
   toggleStreetviewDisplay() {

--- a/src/app/constants/assets.ts
+++ b/src/app/constants/assets.ts
@@ -1,4 +1,4 @@
-export const featureTypes = ['image', 'video', 'point_cloud', 'no_asset_vector'] as const;
+export const featureTypes = ['image', 'video', 'point_cloud', 'streetview', 'no_asset_vector'] as const;
 
 type featuresTypeID = typeof featureTypes[number];
 
@@ -6,5 +6,6 @@ export const featureTypeLabels: Record<featuresTypeID, string> = {
   image: 'Images',
   video: 'Videos',
   point_cloud: 'Point Clouds',
+  streetview: 'Streetview',
   no_asset_vector: 'No Asset Vector'
 } as const;

--- a/src/app/services/env.service.ts
+++ b/src/app/services/env.service.ts
@@ -117,9 +117,7 @@ export class EnvService {
         mapillary: {
           clientSecret: 'MLY|4866220476802272|909ed0e2baefa5d5c195710f5c83f98b',
           clientId: '4866220476802272',
-          clientToken: 'MLY|4866220476802272|cedfb10deac752ca3ddf83997cef60a4',
-          mapToken:
-            'MLYARDcnHyGduYMTxCn5gVuhZCFPHQAFhZBUX1JGw25udGnTa6YunU3UYUZBsmiIykVApTBwxHguCyTZAdGvHavJ6O7mr3uPA3ZC3ZCOwkTg2HiVR8AoR5Om2Dhw2vAOawgZDZD',
+          clientToken: 'MLY|4866220476802272|cedfb10deac752ca3ddf83997cef60a4'
         },
       };
       // local devevelopers can use localhost or hazmapper.local but
@@ -146,9 +144,7 @@ export class EnvService {
         mapillary: {
           clientSecret: 'MLY|4936281379826603|cafd014ccd8cfc983e47c69c16082c7b',
           clientId: '4936281379826603',
-          clientToken: 'MLY|4936281379826603|f8c4732d3c9d96582b86158feb1c1a7a',
-          mapToken:
-            'MLYARDcnHyGduYMTxCn5gVuhZCFPHQAFhZBUX1JGw25udGnTa6YunU3UYUZBsmiIykVApTBwxHguCyTZAdGvHavJ6O7mr3uPA3ZC3ZCOwkTg2HiVR8AoR5Om2Dhw2vAOawgZDZD',
+          clientToken: 'MLY|4936281379826603|f8c4732d3c9d96582b86158feb1c1a7a'
         },
       };
     } else if (/^hazmapper.tacc.utexas.edu/.test(hostname)) {
@@ -166,9 +162,7 @@ export class EnvService {
         mapillary: {
           clientSecret: 'MLY|5156692464392931|6be48c9f4074f4d486e0c42a012b349f',
           clientId: '5156692464392931',
-          clientToken: 'MLY|5156692464392931|4f1118aa1b06f051a44217cb56bedf79',
-          mapToken:
-            'MLYARDcnHyGduYMTxCn5gVuhZCFPHQAFhZBUX1JGw25udGnTa6YunU3UYUZBsmiIykVApTBwxHguCyTZAdGvHavJ6O7mr3uPA3ZC3ZCOwkTg2HiVR8AoR5Om2Dhw2vAOawgZDZD',
+          clientToken: 'MLY|5156692464392931|4f1118aa1b06f051a44217cb56bedf79'
         },
       };
     } else {

--- a/src/app/services/streetview-authentication.service.ts
+++ b/src/app/services/streetview-authentication.service.ts
@@ -41,18 +41,18 @@ export class StreetviewAuthenticationService {
     );
   }
 
-  public isLoggedIn(service: string): boolean {
+  public isLoggedIn(service: string, isPublicView: boolean = false): boolean {
     const userToken: AuthToken = this.getLocalToken(service);
 
-    if (!this._activeStreetview.getValue()) {
+    if (!isPublicView && !this._activeStreetview.getValue()) {
       return false;
     }
 
     return userToken && !userToken.isExpired();
   }
 
-  public login(service: string, projectId: number) {
-    this.tokenRequest(service, projectId);
+  public login(service: string, projectId: number, isPublicView: boolean) {
+    this.tokenRequest(service, projectId, isPublicView);
   }
 
   public logout(service: string): void {
@@ -153,7 +153,7 @@ export class StreetviewAuthenticationService {
     );
   }
 
-  private tokenRequest(service: string, projectId: number): void {
+  private tokenRequest(service: string, projectId: number, isPublicView: boolean): void {
     const envs = this.envService.streetviewEnv[service];
     const secretEnvs = this.envService.streetviewEnv.secrets[service];
 
@@ -162,6 +162,7 @@ export class StreetviewAuthenticationService {
       service,
       projectId,
       username: this._username,
+      isPublicView
     });
 
     const callback =

--- a/src/app/services/streetview.service.ts
+++ b/src/app/services/streetview.service.ts
@@ -298,17 +298,18 @@ export class StreetviewService {
       }
     };
 
-    return this.getMapillaryImages(sequenceId)
-      .pipe(
-        map(e => {
-          const [img] = e.data;
-          layerData.layer.properties.image_id = img.id;
-          return layerData;
-        }),
-        catchError((err) => {
-          return of(layerData);
-        })
-      )
+    if (this.streetviewAuthentication.isLoggedIn('mapillary')) {
+      return this.getMapillaryImages(sequenceId)
+        .pipe(
+          map(e => {
+            const [img] = e.data;
+            layerData.layer.properties.image_id = img.id;
+            return layerData;
+          }),
+        );
+    } else {
+      return of(layerData);
+    }
   }
 
   public get activeAsset() {


### PR DESCRIPTION
## Overview: ##
I was getting a 403 on trying to get mapillary assets due to the `mapToken` being expired.
So we have to use the user's token to access mapillary assets and the mapillary viewer.
Original intention was to allow public users to access the assets without having to login to mapillary.
But it seems like it is necessary.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2273](https://jira.tacc.utexas.edu/browse/DES-2273)

## Summary of Changes: ##
- Added `streetview` asset type to filters in order to allow it to appear among the map assets.
- Added mapillary panel and login to public maps.
- Removed `mapToken` and use mapillary user token for accessing mapillary assets.

## Testing Steps: ##
1. Login to mapillary with a private map.
2. Link map assets (among the ones you have in mapillary [i.e. through linking ones shown when 'Display Mapillary Sequences' is enabled])
3. Link the sequences to map assets so that they show in the Assets panel.
4. Ensure that. they show up in the asset panel (might have to refresh) -> tests if filter works
5. Ensure that right click/left click on the streetview assets work.
6. Destroy the streetview service (in Streetview -> Accounts)
7. Change to the public version of the map
8. Login again with the public version
9. Ensure that right click/left click on streetview assets work.

## UI Photos:

## Notes: ##
