### PR TITLE
hotfix:  fixes CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,8 @@ on:
     branches: [ '**' ]
 
 jobs:
-  Angular-Unit_Tests:
-    runs-on: ubuntu-18.04
+  Angular-Unit-Tests:
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Node.js for use with actions
@@ -34,7 +34,7 @@ jobs:
         npm run test:ci
 
   Angular-Linting:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Node.js for use with actions
@@ -57,8 +57,8 @@ jobs:
       run: |
         cd angular
         npm run lint
-  React-Unit_Tests:
-    runs-on: ubuntu-18.04
+  React-Unit-Tests:
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js for use with actions
@@ -82,7 +82,7 @@ jobs:
           cd react
           npm run test
   React-Linting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Node.js for use with actions


### PR DESCRIPTION
## Overview: ##

ubuntu 18.04 runner is deprecated ( https://github.com/actions/runner-images/pull/7388 ) as noted in [WG-29](https://jira.tacc.utexas.edu/browse/WG-29).  Bumping runner to ubuntu-latest (22.04)

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-29](https://jira.tacc.utexas.edu/browse/WG-29)

## Testing Steps: ##
1. Check that CI is running
