### PR TITLE
Task/WG-79: fix zoom level

### DIFF
--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -32,7 +32,7 @@
         "leaflet": "^1.4.0",
         "leaflet.markercluster": "^1.4.1",
         "mapillary-js": "^4.1.0",
-        "ng-tapis": "^2.1.6",
+        "ng-tapis": "2.1.6",
         "ngx-toastr": "^11.3.3",
         "patch-package": "^6.4.7",
         "rxjs": "~6.5.3",
@@ -10275,6 +10275,10 @@
       "integrity": "sha512-r2JQu7Rz2xysPXPSRfYE5LjAWBrk5tk4AzCcU+FHxTyElJHJ+T+vDU7Wonuz6+Y3EnpYOLP5wObeKkKw5AG0Wg==",
       "dependencies": {
         "tslib": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^8.2.4",
+        "@angular/core": "^8.2.4"
       }
     },
     "node_modules/ngx-filesize": {

--- a/angular/package.json
+++ b/angular/package.json
@@ -42,7 +42,7 @@
     "leaflet": "^1.4.0",
     "leaflet.markercluster": "^1.4.1",
     "mapillary-js": "^4.1.0",
-    "ng-tapis": "^2.1.6",
+    "ng-tapis": "2.1.6",
     "ngx-toastr": "^11.3.3",
     "patch-package": "^6.4.7",
     "rxjs": "~6.5.3",

--- a/angular/src/app/components/map/map.component.ts
+++ b/angular/src/app/components/map/map.component.ts
@@ -66,6 +66,8 @@ export class MapComponent implements OnInit, OnDestroy {
 
   mapillaryLayer: any;
 
+  private readonly MAX_FIT_TO_BOUNDS_ZOOM = 18;
+
   constructor(
     private projectsService: ProjectsService,
     private geoDataService: GeoDataService,
@@ -188,7 +190,7 @@ export class MapComponent implements OnInit, OnDestroy {
           [bbox[1], bbox[0]],
           [bbox[3], bbox[2]],
         ],
-          {maxZoom: 18});
+          {maxZoom: this.MAX_FIT_TO_BOUNDS_ZOOM});
       })
     );
 
@@ -375,7 +377,7 @@ export class MapComponent implements OnInit, OnDestroy {
       try {
         if (this.fitToFeatureExtent) {
           this.fitToFeatureExtent = false;
-          this.map.fitBounds(this.features.getBounds());
+          this.map.fitBounds(this.features.getBounds(), {maxZoom: this.MAX_FIT_TO_BOUNDS_ZOOM});
         }
       } catch (e) {}
     });

--- a/angular/src/app/components/map/map.component.ts
+++ b/angular/src/app/components/map/map.component.ts
@@ -187,7 +187,8 @@ export class MapComponent implements OnInit, OnDestroy {
         this.map.fitBounds([
           [bbox[1], bbox[0]],
           [bbox[3], bbox[2]],
-        ]);
+        ],
+          {maxZoom: 18});
       })
     );
 

--- a/angular/src/app/components/map/map.component.ts
+++ b/angular/src/app/components/map/map.component.ts
@@ -186,11 +186,13 @@ export class MapComponent implements OnInit, OnDestroy {
       this.geoDataService.activeFeature.pipe(filter((n) => n != null)).subscribe((next) => {
         this.activeFeature = next;
         const bbox = turf.bbox(<AllGeoJSON>next);
-        this.map.fitBounds([
-          [bbox[1], bbox[0]],
-          [bbox[3], bbox[2]],
-        ],
-          {maxZoom: this.MAX_FIT_TO_BOUNDS_ZOOM});
+        this.map.fitBounds(
+          [
+            [bbox[1], bbox[0]],
+            [bbox[3], bbox[2]],
+          ],
+          { maxZoom: this.MAX_FIT_TO_BOUNDS_ZOOM }
+        );
       })
     );
 
@@ -377,7 +379,7 @@ export class MapComponent implements OnInit, OnDestroy {
       try {
         if (this.fitToFeatureExtent) {
           this.fitToFeatureExtent = false;
-          this.map.fitBounds(this.features.getBounds(), {maxZoom: this.MAX_FIT_TO_BOUNDS_ZOOM});
+          this.map.fitBounds(this.features.getBounds(), { maxZoom: this.MAX_FIT_TO_BOUNDS_ZOOM });
         }
       } catch (e) {}
     });


### PR DESCRIPTION
## Overview: ##

This PR fixes zoom level on the project load and also when selecting asset.

Hazmapper fits to project bounds when loading and fits a single asset bound when the asset is selected which for points can be the max zoom of our entire map which is too high.  Now, we have max zoom of 18 when zooming to assets or to the entire project.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-79](https://jira.tacc.utexas.edu/browse/WG-79)

## Summary of Changes: ##

## Testing Steps: ##
1. set `angular/src/environments/environment.ts` set `backend` to EnvironmentType.Production or EnvironmentType.Staging
`npm run start:local`
2. Go to http://hazmapper.local:4200/
3. Find project with asset
4. Click on an asset and confirm zoom isn't as close as what you would see when viewing the project hazmapper.tacc.utexas.edu/hazmapper
5. OIf the project has just one asset, you can also confirm that when it loads that it doesn't zoom as close as production.

## UI Photos:
Before: 
![Screenshot 2023-06-02 at 12 05 19 PM](https://github.com/TACC-Cloud/hazmapper/assets/8287580/6dd46260-6747-4d73-bb58-7bbc1c879dd6)

After:

![Screenshot 2023-06-02 at 12 04 52 PM](https://github.com/TACC-Cloud/hazmapper/assets/8287580/78913f32-2e32-4581-8417-61793f493546)
