### PR TITLE
task/WG-78: remove asset delete button from public map view

### DIFF
--- a/angular/src/app/components/assets-panel/assets-panel.component.html
+++ b/angular/src/app/components/assets-panel/assets-panel.component.html
@@ -18,7 +18,8 @@
         [alwaysCallback]="true"
         [scrollWindow]="false"
     >
-        <app-file-tree-node [isPublicView]="isPublicView" [node]="currentTreeListing" (clickEvent)="selectTreeNode($event)"> </app-file-tree-node>
+        <app-file-tree-node [isPublicView]="isPublicView" [node]="currentTreeListing" (clickEvent)="selectTreeNode($event)">
+        </app-file-tree-node>
     </div>
     <div class="dock-panel-controls">
         <div class="expanded button-group tiny">

--- a/angular/src/app/components/assets-panel/assets-panel.component.html
+++ b/angular/src/app/components/assets-panel/assets-panel.component.html
@@ -18,7 +18,7 @@
         [alwaysCallback]="true"
         [scrollWindow]="false"
     >
-        <app-file-tree-node [node]="currentTreeListing" (clickEvent)="selectTreeNode($event)"> </app-file-tree-node>
+        <app-file-tree-node [isPublicView]="isPublicView" [node]="currentTreeListing" (clickEvent)="selectTreeNode($event)"> </app-file-tree-node>
     </div>
     <div class="dock-panel-controls">
         <div class="expanded button-group tiny">

--- a/angular/src/app/components/feature-row/feature-row.component.html
+++ b/angular/src/app/components/feature-row/feature-row.component.html
@@ -3,7 +3,7 @@
         <app-feature-icon [feature]="feature"></app-feature-icon>
         <div>{{ feature.properties.label || feature.id }}</div>
     </div>
-    <div class="cell large-3 grid-x align-right">
+    <div *ngIf="!isPublicView" class="cell large-3 grid-x align-right">
         <button class="button tiny alert hollow" (click)="delete()">
             <i class="fas fa-trash"></i>
         </button>

--- a/angular/src/app/components/feature-row/feature-row.component.ts
+++ b/angular/src/app/components/feature-row/feature-row.component.ts
@@ -8,6 +8,7 @@ import { GeoDataService } from '../../services/geo-data.service';
   styleUrls: ['./feature-row.component.styl'],
 })
 export class FeatureRowComponent implements OnInit {
+  @Input() isPublicView = false;
   @Input() feature: Feature;
   @Output() clickRequest = new EventEmitter<Feature>();
   constructor(private geoDataService: GeoDataService) {}

--- a/angular/src/app/components/file-tree-node/file-tree-node.component.html
+++ b/angular/src/app/components/file-tree-node/file-tree-node.component.html
@@ -9,7 +9,7 @@
             <app-feature-icon [feature]="node.getPayload()"></app-feature-icon>
             {{ node.getPath() }}
         </div>
-        <div class="grid-x align-middle" *ngIf="isActiveFeature()">
+        <div class="grid-x align-middle" *ngIf="isActiveFeature() && !isPublicView">
             <button class="button tiny alert hollow" (click)="delete(node)">
                 <i class="fas fa-trash"></i>
             </button>
@@ -20,6 +20,7 @@
             <cdk-virtual-scroll-viewport class="scroll-viewport" itemSize="10">
                 <app-file-tree-node
                     *cdkVirtualFor="let child of node.getChildrenAsArray()"
+                    [isPublicView]="isPublicView"
                     [node]="child"
                     class="scroll-item"
                     (clickEvent)="onClickChild($event)"
@@ -30,6 +31,7 @@
         </ng-container>
         <ng-template #smallList>
             <app-file-tree-node
+                [isPublicView]="isPublicView"
                 *ngFor="let child of node.getChildren()"
                 [node]="child"
                 class="example-item"

--- a/angular/src/app/components/file-tree-node/file-tree-node.component.ts
+++ b/angular/src/app/components/file-tree-node/file-tree-node.component.ts
@@ -23,6 +23,7 @@ import { StreetviewService } from 'src/app/services/streetview.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FileTreeNodeComponent implements OnInit, OnDestroy {
+  @Input() isPublicView = false;
   @Input() node: PathTree<Feature>;
   @Output() clickEvent: EventEmitter<PathTree<Feature>> = new EventEmitter<PathTree<Feature>>();
   public activeFeature: Feature;


### PR DESCRIPTION
## Overview: ##

Remove asset delete button when viewing public view of map.


## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-78](https://jira.tacc.utexas.edu/browse/WG-78)

## Testing Steps: ##
1. Load a map
2. See that the delete button is available for the selected asset
3. Load the public version of map, and ensure that delete button is NOT there for the selected asset

## UI Photos:
Private view with delete button
![Screenshot 2023-06-02 at 4 57 56 PM](https://github.com/TACC-Cloud/hazmapper/assets/8287580/5866823f-399f-447a-bf0b-5004253e34d5)

Public view WITHOUT delete button
![Screenshot 2023-06-02 at 4 57 40 PM](https://github.com/TACC-Cloud/hazmapper/assets/8287580/f1e46174-303b-485b-be3f-ec4c63cf1d6e)
