### PR TITLE
Task/wg 145 fix spinner error on project listing page

### DIFF
--- a/angular/src/app/components/main-welcome/main-welcome.component.html
+++ b/angular/src/app/components/main-welcome/main-welcome.component.html
@@ -37,8 +37,12 @@
                     <div *ngIf="projectsData.failedMessage || dsProjectsData.failedMessage; else projectConnected">
                         <div id="welcome-no-information">
                             <div>Failed to Connect to Server!</div>
-                            <div *ngIf="projectsData.failedMessage"><small>Unable to get maps: {{projectsData.failedMessage}}</small></div>
-                            <div *ngIf="dsProjectsData.failedMessage"><small>Unable to get projects: {{dsProjectsData.failedMessage}}</small></div>
+                            <div *ngIf="projectsData.failedMessage">
+                                <small>Unable to get maps: {{ projectsData.failedMessage }}</small>
+                            </div>
+                            <div *ngIf="dsProjectsData.failedMessage">
+                                <small>Unable to get projects: {{ dsProjectsData.failedMessage }}</small>
+                            </div>
                         </div>
                     </div>
 

--- a/angular/src/app/components/main-welcome/main-welcome.component.html
+++ b/angular/src/app/components/main-welcome/main-welcome.component.html
@@ -24,7 +24,7 @@
                     </div>
                 </div>
 
-                <div *ngIf="spinner; else projectLoaded">
+                <div *ngIf="loadingProjects; else projectLoaded">
                     <div id="welcome-no-information">
                         <div>
                             Loading Projects
@@ -34,15 +34,17 @@
                 </div>
 
                 <ng-template #projectLoaded>
-                    <div *ngIf="notConnected; else projectConnected">
+                    <div *ngIf="projectsData.loadingProjectsFailed; else projectConnected">
                         <div id="welcome-no-information">
                             <div>Failed to Connect to Server!</div>
+                            <div *ngIf="projectsData.loadingProjectsFailed"><small>Unable to get projects</small></div>
+                            <div *ngIf="projectsData.loadingProjectsFailedMessage"><small>Error {{projectsData.loadingProjectsFailedMessage}}</small></div>
                         </div>
                     </div>
 
                     <ng-template #projectConnected>
-                        <div *ngIf="projects.length > 0; else noProject" class="project-list-container">
-                            <div *ngFor="let p of projects; let indexOfElement = index">
+                        <div *ngIf="projectsData.projects.length > 0; else noProject" class="project-list-container">
+                            <div *ngFor="let p of projectsData.projects; let indexOfElement = index">
                                 <div
                                     (click)="routeToProject(p.uuid)"
                                     class="project-list-item"

--- a/angular/src/app/components/main-welcome/main-welcome.component.html
+++ b/angular/src/app/components/main-welcome/main-welcome.component.html
@@ -24,7 +24,7 @@
                     </div>
                 </div>
 
-                <div *ngIf="loadingProjects; else projectLoaded">
+                <div *ngIf="loading; else projectLoaded">
                     <div id="welcome-no-information">
                         <div>
                             Loading Projects
@@ -34,11 +34,11 @@
                 </div>
 
                 <ng-template #projectLoaded>
-                    <div *ngIf="projectsData.loadingProjectsFailed; else projectConnected">
+                    <div *ngIf="projectsData.failedMessage || dsProjectsData.failedMessage; else projectConnected">
                         <div id="welcome-no-information">
                             <div>Failed to Connect to Server!</div>
-                            <div *ngIf="projectsData.loadingProjectsFailed"><small>Unable to get projects</small></div>
-                            <div *ngIf="projectsData.loadingProjectsFailedMessage"><small>Error {{projectsData.loadingProjectsFailedMessage}}</small></div>
+                            <div *ngIf="projectsData.failedMessage"><small>Unable to get maps: {{projectsData.failedMessage}}</small></div>
+                            <div *ngIf="dsProjectsData.failedMessage"><small>Unable to get projects: {{dsProjectsData.failedMessage}}</small></div>
                         </div>
                     </div>
 

--- a/angular/src/app/components/main-welcome/main-welcome.component.ts
+++ b/angular/src/app/components/main-welcome/main-welcome.component.ts
@@ -46,18 +46,19 @@ export class MainWelcomeComponent implements OnInit {
       }
     });
 
-    combineLatest(
-      [this.projectsService.projectsData, this.agaveSystemsService.projectsData]).subscribe(([projectsData, dsProjectsData]) => {
-      this.projectsData = projectsData;
-      this.dsProjectsData = dsProjectsData;
-      if (!this.projectsData.loading && !this.dsProjectsData.loading) {
-        if(this.projectsData.failedMessage && !this.dsProjectsData.failedMessage) {
-          // add extra info (i.e. DS project id/description) from related DS projects
-          this.projectsData.projects = this.agaveSystemsService.getProjectMetadata(projectsData.projects, dsProjectsData.projects);
+    combineLatest([this.projectsService.projectsData, this.agaveSystemsService.projectsData]).subscribe(
+      ([projectsData, dsProjectsData]) => {
+        this.projectsData = projectsData;
+        this.dsProjectsData = dsProjectsData;
+        if (!this.projectsData.loading && !this.dsProjectsData.loading) {
+          if (this.projectsData.failedMessage && !this.dsProjectsData.failedMessage) {
+            // add extra info (i.e. DS project id/description) from related DS projects
+            this.projectsData.projects = this.agaveSystemsService.getProjectMetadata(projectsData.projects, dsProjectsData.projects);
+          }
+          this.loading = false;
         }
-        this.loading = false;
       }
-    });
+    );
   }
 
   routeToProject(projectUUID: string) {

--- a/angular/src/app/components/main-welcome/main-welcome.component.ts
+++ b/angular/src/app/components/main-welcome/main-welcome.component.ts
@@ -3,7 +3,7 @@ import { Project } from '../../models/models';
 import { Streetview } from '../../models/streetview';
 import { ProjectsService, ProjectsData } from '../../services/projects.service';
 import { BsModalRef, BsModalService } from 'ngx-foundation';
-import { AgaveSystemsService } from '../../services/agave-systems.service';
+import { AgaveSystemsService, AgaveProjectsData } from '../../services/agave-systems.service';
 import { ModalCreateProjectComponent } from '../modal-create-project/modal-create-project.component';
 import { Router, ActivatedRoute } from '@angular/router';
 import { ModalService } from 'src/app/services/modal.service';
@@ -21,11 +21,9 @@ export class MainWelcomeComponent implements OnInit {
   release_url = 'https://github.com/TACC-cloud/hazmapper';
   guide_url = 'https://www.designsafe-ci.org/rw/user-guides/tools-applications/visualization/hazmapper/';
 
-  loadingProjects = true;
-
-  public projectsData: ProjectsData;
-
-  public activeProject: Project;
+  private projectsData: ProjectsData;
+  private dsProjectsData: AgaveProjectsData;
+  private loading = true;
 
   constructor(
     private route: ActivatedRoute,
@@ -48,11 +46,17 @@ export class MainWelcomeComponent implements OnInit {
       }
     });
 
-    combineLatest([this.projectsService.projectsData, this.agaveSystemsService.projects]).subscribe(([projectsData, dsProjects]) => {
+    combineLatest(
+      [this.projectsService.projectsData, this.agaveSystemsService.projectsData]).subscribe(([projectsData, dsProjectsData]) => {
       this.projectsData = projectsData;
-      // add extra info from related DS projects
-      this.projectsData.projects = this.agaveSystemsService.getProjectMetadata(projectsData.projects, dsProjects);
-      this.loadingProjects = false;
+      this.dsProjectsData = dsProjectsData;
+      if (!this.projectsData.loading && !this.dsProjectsData.loading) {
+        if(this.projectsData.failedMessage && !this.dsProjectsData.failedMessage) {
+          // add extra info (i.e. DS project id/description) from related DS projects
+          this.projectsData.projects = this.agaveSystemsService.getProjectMetadata(projectsData.projects, dsProjectsData.projects);
+        }
+        this.loading = false;
+      }
     });
   }
 

--- a/angular/src/app/components/main-welcome/main-welcome.component.ts
+++ b/angular/src/app/components/main-welcome/main-welcome.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Project } from '../../models/models';
 import { Streetview } from '../../models/streetview';
-import { ProjectsService } from '../../services/projects.service';
+import { ProjectsService, ProjectsData } from '../../services/projects.service';
 import { BsModalRef, BsModalService } from 'ngx-foundation';
 import { AgaveSystemsService } from '../../services/agave-systems.service';
 import { ModalCreateProjectComponent } from '../modal-create-project/modal-create-project.component';
@@ -21,10 +21,10 @@ export class MainWelcomeComponent implements OnInit {
   release_url = 'https://github.com/TACC-cloud/hazmapper';
   guide_url = 'https://www.designsafe-ci.org/rw/user-guides/tools-applications/visualization/hazmapper/';
 
-  spinner = true;
-  notConnected: boolean;
+  loadingProjects = true;
 
-  public projects = [];
+  public projectsData: ProjectsData;
+
   public activeProject: Project;
 
   constructor(
@@ -48,13 +48,11 @@ export class MainWelcomeComponent implements OnInit {
       }
     });
 
-    this.projectsService.loadingProjectsFailed.subscribe((notConnected) => {
-      this.notConnected = notConnected;
-    });
-
-    combineLatest([this.projectsService.projects, this.agaveSystemsService.projects]).subscribe(([projects, dsProjects]) => {
-      this.projects = this.agaveSystemsService.getProjectMetadata(projects, dsProjects);
-      this.spinner = false;
+    combineLatest([this.projectsService.projectsData, this.agaveSystemsService.projects]).subscribe(([projectsData, dsProjects]) => {
+      this.projectsData = projectsData;
+      // add extra info from related DS projects
+      this.projectsData.projects = this.agaveSystemsService.getProjectMetadata(projectsData.projects, dsProjects);
+      this.loadingProjects = false;
     });
   }
 

--- a/angular/src/app/services/agave-systems.service.ts
+++ b/angular/src/app/services/agave-systems.service.ts
@@ -35,11 +35,7 @@ export class AgaveSystemsService {
     private envService: EnvService,
     private http: HttpClient
   ) {
-    this.projectsData = combineLatest([
-      this.projects,
-      this.loadingProjectsFailedMessage,
-      this.loadingProjects,
-    ]).pipe(
+    this.projectsData = combineLatest([this.projects, this.loadingProjectsFailedMessage, this.loadingProjects]).pipe(
       map(([projects, failedMessage, loading]) => ({
         projects,
         failedMessage,

--- a/angular/src/app/services/agave-systems.service.ts
+++ b/angular/src/app/services/agave-systems.service.ts
@@ -2,10 +2,17 @@ import { Injectable } from '@angular/core';
 import { System, SystemSummary } from 'ng-tapis';
 import { ApiService } from 'ng-tapis';
 import { NotificationsService } from './notifications.service';
-import { BehaviorSubject, Observable, ReplaySubject } from 'rxjs';
+import { BehaviorSubject, Observable, ReplaySubject, combineLatest } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { EnvService } from '../services/env.service';
 import { DesignSafeProjectCollection, Project, AgaveFileOperations } from '../models/models';
+
+export interface AgaveProjectsData {
+  projects: SystemSummary[];
+  failedMessage: string | null;
+  loading: boolean;
+}
 
 @Injectable({
   providedIn: 'root',
@@ -13,14 +20,33 @@ import { DesignSafeProjectCollection, Project, AgaveFileOperations } from '../mo
 export class AgaveSystemsService {
   private _systems: ReplaySubject<SystemSummary[]> = new ReplaySubject<SystemSummary[]>(1);
   public readonly systems: Observable<SystemSummary[]> = this._systems.asObservable();
+
   private _projects: ReplaySubject<SystemSummary[]> = new ReplaySubject<SystemSummary[]>(1);
   public readonly projects: Observable<SystemSummary[]> = this._projects.asObservable();
+  private _loadingProjects: BehaviorSubject<boolean> = new BehaviorSubject(true);
+  public loadingProjects: Observable<boolean> = this._loadingProjects.asObservable();
+  private _loadingProjectsFailedMessage: BehaviorSubject<string> = new BehaviorSubject('');
+  public loadingProjectsFailedMessage: Observable<string> = this._loadingProjectsFailedMessage.asObservable();
+  public readonly projectsData: Observable<AgaveProjectsData>;
+
   constructor(
     private tapis: ApiService,
     private notificationsService: NotificationsService,
     private envService: EnvService,
     private http: HttpClient
-  ) {}
+  ) {
+    this.projectsData = combineLatest([
+      this.projects,
+      this.loadingProjectsFailedMessage,
+      this.loadingProjects,
+    ]).pipe(
+      map(([projects, failedMessage, loading]) => ({
+        projects,
+        failedMessage,
+        loading,
+      }))
+    );
+  }
 
   list() {
     this.tapis.systemsList({ type: 'STORAGE' }).subscribe(
@@ -31,6 +57,11 @@ export class AgaveSystemsService {
         this._systems.next(null);
       }
     );
+
+    this._projects.next(null);
+    this._loadingProjects.next(true);
+    this._loadingProjectsFailedMessage.next(null);
+
     this.http.get<DesignSafeProjectCollection>(this.envService.designSafeUrl + `/projects/v2/`).subscribe(
       (resp) => {
         const projectSystems = resp.projects.map((project) => {
@@ -41,9 +72,12 @@ export class AgaveSystemsService {
           };
         });
         this._projects.next(projectSystems);
+        this._loadingProjects.next(false);
       },
       (error) => {
         this._projects.next(null);
+        this._loadingProjectsFailedMessage.next(error.message || 'An error occured.');
+        this._loadingProjects.next(false);
       }
     );
   }

--- a/angular/src/app/services/projects.service.ts
+++ b/angular/src/app/services/projects.service.ts
@@ -14,18 +14,15 @@ import { MAIN, LOGIN } from '../constants/routes';
 import { AgaveSystemsService } from '../services/agave-systems.service';
 import { Router } from '@angular/router';
 
-
 export interface ProjectsData {
   projects: Project[];
   failedMessage: string | null;
   loading: boolean;
 }
 
-
 @Injectable({
   providedIn: 'root',
 })
-
 export class ProjectsService {
   private _projects: BehaviorSubject<Project[]> = new BehaviorSubject([]);
   public readonly projects: Observable<Project[]> = this._projects.asObservable();
@@ -67,11 +64,7 @@ export class ProjectsService {
     private authService: AuthService,
     private envService: EnvService
   ) {
-    this.projectsData = combineLatest([
-      this.projects,
-      this.loadingProjectsFailedMessage,
-      this.loadingProjects,
-    ]).pipe(
+    this.projectsData = combineLatest([this.projects, this.loadingProjectsFailedMessage, this.loadingProjects]).pipe(
       map(([projects, failedMessage, loading]) => ({
         projects,
         failedMessage,

--- a/angular/src/app/services/projects.service.ts
+++ b/angular/src/app/services/projects.service.ts
@@ -17,8 +17,7 @@ import { Router } from '@angular/router';
 
 export interface ProjectsData {
   projects: Project[];
-  loadingProjectsFailed: boolean;
-  loadingProjectsFailedMessage: string | null;
+  failedMessage: string | null;
   loading: boolean;
 }
 
@@ -42,10 +41,7 @@ export class ProjectsService {
   private _loadingProjects: BehaviorSubject<boolean> = new BehaviorSubject(true);
   public loadingProjects: Observable<boolean> = this._loadingProjects.asObservable();
 
-  private _loadingProjectsFailed: BehaviorSubject<boolean> = new BehaviorSubject(false);
-  public loadingProjectsFailed: Observable<boolean> = this._loadingProjectsFailed.asObservable();
-
-  private _loadingProjectsFailedMessage: BehaviorSubject<string> = new BehaviorSubject("");
+  private _loadingProjectsFailedMessage: BehaviorSubject<string> = new BehaviorSubject('');
   public loadingProjectsFailedMessage: Observable<string> = this._loadingProjectsFailedMessage.asObservable();
 
   public readonly projectsData: Observable<ProjectsData>;
@@ -73,14 +69,12 @@ export class ProjectsService {
   ) {
     this.projectsData = combineLatest([
       this.projects,
-      this.loadingProjectsFailed,
       this.loadingProjectsFailedMessage,
       this.loadingProjects,
     ]).pipe(
-      map(([projects, loadingProjectsFailed, loadingProjectsFailedMessage, loading]) => ({
+      map(([projects, failedMessage, loading]) => ({
         projects,
-        loadingProjectsFailed,
-        loadingProjectsFailedMessage,
+        failedMessage,
         loading,
       }))
     );
@@ -105,20 +99,16 @@ export class ProjectsService {
 
   getProjects(): void {
     this._loadingProjects.next(true);
-    this._loadingProjectsFailed.next(false);
     this._loadingProjectsFailedMessage.next(null);
     this.http.get<Project[]>(this.envService.apiUrl + `/projects/`).subscribe(
       (resp) => {
         this.updateProjectsList(resp);
         this._loadingProjects.next(false);
-        this._loadingProjectsFailed.next(false);
         this._loadingProjectsFailedMessage.next(null);
       },
       (error) => {
         this._loadingProjects.next(false);
-        this._loadingProjectsFailed.next(true);
         this._loadingProjectsFailedMessage.next(error.message || 'An error occured.');
-        this.notificationsService.showErrorToast('Failed to retrieve project data! Geoapi might be down.');
       }
     );
   }


### PR DESCRIPTION
## Overview: ##

Fix spinner and improve error messaging on the main project listing page.

There are two backend requests that need to be completed before we show the listing.  Now we show spinner while waiting for both to complete instead of one to complete. 

If either request fails, we alert the user. See screenshot.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-145](https://jira.tacc.utexas.edu/browse/WG-145)

## Testing Steps: ##
1. See if it runs. 
2. you could alter `projects/v2` request in agave-systems.services.ts to make it fail and see error message
3. you could alter `getProjects` of projects.services.ts to make it fail and see error message

## UI Photos:
<img width="1291" alt="Screenshot 2023-09-18 at 8 55 09 PM" src="https://github.com/TACC-Cloud/hazmapper/assets/8287580/940a527a-3770-4843-8326-ee93e786904f">

