### PR TITLE
Remove duplicate download button

### DIFF
--- a/angular/src/app/components/asset-detail/asset-detail.component.html
+++ b/angular/src/app/components/asset-detail/asset-detail.component.html
@@ -29,28 +29,19 @@
                 <button class="button small">Download</button>
             </a>
         </div>
-        <div class="cell medium-1 text-center asset-detail-action">
-            <div *ngIf="feature.featureType() === 'image'">
-                <a [href]="featureSource" download="feature-{{ feature.id }}.jpeg">
-                    <button class="button small">Download</button>
-                </a>
-            </div>
-            <div *ngIf="feature.featureType() === 'point_cloud'">
-                <a [href]="featureSource + '/index.html'" target="_blank">
-                    <button class="button small">View</button>
-                </a>
-            </div>
-            <div *ngIf="!feature.assets.length" class="text-center">
-                <div data-alert class="alert-box secondary">Feature has no asset.</div>
-                <button class="button expanded hollow" (click)="openFileBrowserModal()" *ngIf="!isPublicView">
-                    Add asset from DesignSafe
-                </button>
-            </div>
-            <hr />
+        <div *ngIf="feature.featureType() === 'point_cloud'">
+            <a [href]="featureSource + '/index.html'" target="_blank">
+                <button class="button small">View</button>
+            </a>
         </div>
-        <div class="cell medium-5 asset-detail-content">
-            <app-feature-metadata [feature]="feature"></app-feature-metadata>
-            <app-feature-geometry [feature]="feature"></app-feature-geometry>
+        <div *ngIf="!feature.assets.length" class="text-center">
+            <div data-alert class="alert-box secondary">Feature has no asset.</div>
+            <button class="button expanded hollow" (click)="openFileBrowserModal()" *ngIf="!isPublicView">Add asset from DesignSafe</button>
         </div>
+        <hr />
+    </div>
+    <div class="cell medium-5 asset-detail-content">
+        <app-feature-metadata [feature]="feature"></app-feature-metadata>
+        <app-feature-geometry [feature]="feature"></app-feature-geometry>
     </div>
 </div>


### PR DESCRIPTION
## Overview: ##

Remove the duplicate download button for images

Regression probably in merge conflict in https://github.com/TACC-Cloud/hazmapper/pull/118

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

None

## Summary of Changes: ##

## Testing Steps: ##
1. View image panel on right for a selected image asset and confirm just one download button.
