### PR TITLE
Patch/make environment type configurable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Node.js for use with actions
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
+        node-version: 14.x
 
     - uses: actions/cache@v1
       with:
@@ -40,7 +40,7 @@ jobs:
     - name: Setup Node.js for use with actions
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
+        node-version: 14.x
 
     - uses: actions/cache@v1
       with:

--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -36,6 +36,7 @@
         "leaflet.markercluster": "^1.4.1",
         "mapillary-js": "^4.1.0",
         "ng-tapis": "2.1.6",
+        "ngx-owl-carousel-o": "^2.1.1",
         "ngx-toastr": "^11.3.3",
         "patch-package": "^6.4.7",
         "rxjs": "~6.5.3",
@@ -163,6 +164,9 @@
       "engines": {
         "node": ">= 10.9.0",
         "npm": ">= 6.2.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=3.1 < 3.5"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/ajv": {
@@ -181,6 +185,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
       "integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
       "dev": true
     },
     "node_modules/@angular-devkit/build-angular/node_modules/rxjs": {
@@ -278,6 +283,10 @@
       "engines": {
         "node": ">= 10.9.0",
         "npm": ">= 6.2.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.6.0",
+        "webpack-dev-server": "^3.1.4"
       }
     },
     "node_modules/@angular-devkit/build-webpack/node_modules/rxjs": {
@@ -365,6 +374,9 @@
       "integrity": "sha512-t4TT11YIRGKSNYz5ngZ7trVPKZMtEql2LaPaVQnAZ6Cefrf+1s431mVh7ndPtGTLxRwr6RPTUe+Tc+5e2ROcmg==",
       "dependencies": {
         "tslib": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "8.2.5"
       }
     },
     "node_modules/@angular/cdk": {
@@ -376,6 +388,10 @@
       },
       "optionalDependencies": {
         "parse5": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=7.0.0",
+        "@angular/core": ">=7.0.0"
       }
     },
     "node_modules/@angular/cdk/node_modules/parse5": {
@@ -389,6 +405,7 @@
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-8.0.3.tgz",
       "integrity": "sha512-ZOrZHtDDWO1J7CLGeEUOI9YHjQHGqfUz/SUrNzzTfwctFq77QfXjnYtx+ejk/+h/dwSHQEOQ8aN5sVP6JvDGoA==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "@angular-devkit/architect": "0.800.3",
         "@angular-devkit/core": "8.0.3",
@@ -420,6 +437,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -446,6 +464,10 @@
       "integrity": "sha512-7iSDLVhS+jbVRkECpbTzU9+6IQPS3Wl0CF73EA0sdzPbTC2GKvGfM9WLnIZZIxewkii6Wn1Yb0x0qRdWMT2STA==",
       "dependencies": {
         "tslib": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "8.2.5",
+        "rxjs": "^6.4.0"
       }
     },
     "node_modules/@angular/compiler": {
@@ -480,6 +502,10 @@
       },
       "engines": {
         "node": ">=8.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler": "8.2.5",
+        "typescript": ">=3.4 <3.6"
       }
     },
     "node_modules/@angular/compiler-cli/node_modules/ansi-regex": {
@@ -495,6 +521,7 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "deprecated": "Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies",
       "dev": true,
       "dependencies": {
         "anymatch": "^2.0.0",
@@ -607,6 +634,10 @@
       "integrity": "sha512-cBEiHhLE8VFIdB53seR+nQYNQFlNloKgD7ro26eMazvRF94wBSzO9VrD3+/XmNWdIYibU7PBaXhDCOKTe+ZSHw==",
       "dependencies": {
         "tslib": "^1.9.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^6.4.0",
+        "zone.js": "~0.9.1"
       }
     },
     "node_modules/@angular/forms": {
@@ -615,6 +646,12 @@
       "integrity": "sha512-USJdzopslLC7JVMu7v58SA/g0NWeQeAM16qcR4LHj+wdMbJ+5G64LdZQe9vEHRdgGpgrZU4c2ODAwDEa1MzIDA==",
       "dependencies": {
         "tslib": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "8.2.5",
+        "@angular/core": "8.2.5",
+        "@angular/platform-browser": "8.2.5",
+        "rxjs": "^6.4.0"
       }
     },
     "node_modules/@angular/language-service": {
@@ -629,6 +666,10 @@
       "integrity": "sha512-JIm4uOcgQq0oX1oTzRbQpwxFYAEYKiLi/uAPUf2CZeU2lVxMkhScAW0b8+tVFLIJ7IaVx5d2QxZ6HK81r+QSVg==",
       "dependencies": {
         "tslib": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "8.2.5",
+        "@angular/core": "8.2.5"
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
@@ -637,6 +678,12 @@
       "integrity": "sha512-4Ewg8I3T0t6/ClLt5ZFZ6ncDTqvEyI84h0K1cnNTsyoup3QKrY/FnklFbZbNl4ONVioHS6fkEg3R+xt1WthhYQ==",
       "dependencies": {
         "tslib": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "8.2.5",
+        "@angular/compiler": "8.2.5",
+        "@angular/core": "8.2.5",
+        "@angular/platform-browser": "8.2.5"
       }
     },
     "node_modules/@angular/router": {
@@ -645,6 +692,12 @@
       "integrity": "sha512-htkxrbB8rbOKIcfd0fV9KcxJGnVg8bAJ6atIMPETeI3dBORq6crzvML0B/yx6R+Ooy5e3Td3yXBsolexMxT0mg==",
       "dependencies": {
         "tslib": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "8.2.5",
+        "@angular/core": "8.2.5",
+        "@angular/platform-browser": "8.2.5",
+        "rxjs": "^6.4.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -800,6 +853,11 @@
       "engines": {
         "node": ">= 10.9.0",
         "npm": ">= 6.2.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler-cli": ">=8.0.0-beta.0 < 9.0.0",
+        "typescript": ">=3.4 < 3.5",
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/@ngtools/webpack/node_modules/rxjs": {
@@ -867,6 +925,7 @@
       "version": "0.800.3",
       "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.800.3.tgz",
       "integrity": "sha512-8pPwtr6n23RTNBWp3fEMNvaEM7EN5OyNn8WL+hWkZNQWC3VuUw5b06EnayeS9/VfRI1LENAgfQXqQkdo6/MJyg==",
+      "deprecated": "This was an internal-only Angular package up through Angular v11 which is no longer used or maintained. Upgrade Angular to v12+ to remove this dependency.",
       "dev": true,
       "dependencies": {
         "@angular-devkit/core": "8.0.3",
@@ -2679,7 +2738,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
       "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-      "dev": true
+      "deprecated": "This is probably built in to whatever tool you're using. If you still need it... idk",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0"
+      }
     },
     "node_modules/adm-zip": {
       "version": "0.4.13",
@@ -2736,13 +2799,19 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      }
     },
     "node_modules/ajv-keywords": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
       "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
     },
     "node_modules/amdefine": {
       "version": "1.0.1",
@@ -3685,6 +3754,7 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer",
       "dev": true,
       "dependencies": {
         "base64-js": "^1.0.2",
@@ -4153,6 +4223,9 @@
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": ">=4.0.1"
       }
     },
     "node_modules/class-utils": {
@@ -4323,6 +4396,11 @@
         "semver-dsl": "^1.0.1",
         "source-map": "^0.5.7",
         "sprintf-js": "^1.1.2"
+      },
+      "peerDependencies": {
+        "@angular/compiler": ">=2.3.1 <9.0.0 || >8.0.0-beta <9.0.0 || >8.1.0-beta <9.0.0 || >8.2.0-beta <9.0.0",
+        "@angular/core": ">=2.3.1 <9.0.0 || >8.0.0-beta <9.0.0 || >8.1.0-beta <9.0.0 || >8.2.0-beta <9.0.0",
+        "tslint": "^5.0.0"
       }
     },
     "node_modules/codelyzer/node_modules/source-map": {
@@ -4653,6 +4731,9 @@
       },
       "engines": {
         "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/copy-webpack-plugin/node_modules/normalize-path": {
@@ -4667,7 +4748,8 @@
     "node_modules/core-js": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js."
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -4914,6 +4996,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.0.0.tgz",
       "integrity": "sha512-M6UqVvZVgFYqZL1SfHsRGIQSz3ZL+qgbsV5Lp1Vj61LZVYuEwcMXYay7DRDtYs2HQQBK5hQtQ0fD9aEJ89V0LA==",
+      "deprecated": "2.x is no longer supported. Please upgrade to 4.x or higher.",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -6390,6 +6473,9 @@
       },
       "engines": {
         "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/fileset": {
@@ -6618,6 +6704,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -6689,6 +6776,10 @@
       "engines": {
         "node": ">=6.4.0",
         "npm": ">=2.14.2"
+      },
+      "peerDependencies": {
+        "jquery": ">=2.2.0",
+        "what-input": ">=4.1.0"
       }
     },
     "node_modules/fragment-cache": {
@@ -6786,6 +6877,7 @@
       "bundleDependencies": [
         "node-pre-gyp"
       ],
+      "deprecated": "The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -7709,6 +7801,7 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "deprecated": "this library is no longer supported",
       "dev": true,
       "dependencies": {
         "ajv": "^6.5.5",
@@ -8045,6 +8138,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -8231,6 +8325,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "deprecated": "Please update to ini >=1.3.6 to avoid a prototype pollution issue",
       "dev": true,
       "engines": {
         "node": "*"
@@ -8799,6 +8894,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -9021,6 +9117,9 @@
       },
       "engines": {
         "node": ">= 4.8 < 5.0.0 || >= 5.10"
+      },
+      "peerDependencies": {
+        "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/istanbul-instrumenter-loader/node_modules/ajv": {
@@ -9215,7 +9314,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dependencies": {
+      "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
@@ -9344,6 +9443,10 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      },
+      "peerDependencies": {
+        "jasmine-core": "*",
+        "karma": "*"
       }
     },
     "node_modules/karma-jasmine-html-reporter": {
@@ -9353,6 +9456,9 @@
       "dev": true,
       "dependencies": {
         "karma-jasmine": "^1.0.2"
+      },
+      "peerDependencies": {
+        "karma": ">=0.9"
       }
     },
     "node_modules/karma-source-map-support": {
@@ -9466,7 +9572,10 @@
     "node_modules/leaflet.markercluster": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.4.1.tgz",
-      "integrity": "sha512-ZSEpE/EFApR0bJ1w/dUGwTSUvWlpalKqIzkaYdYB7jaftQA/Y2Jav+eT4CMtEYFj+ZK4mswP13Q2acnPBnhGOw=="
+      "integrity": "sha512-ZSEpE/EFApR0bJ1w/dUGwTSUvWlpalKqIzkaYdYB7jaftQA/Y2Jav+eT4CMtEYFj+ZK4mswP13Q2acnPBnhGOw==",
+      "peerDependencies": {
+        "leaflet": "~1.3.1"
+      }
     },
     "node_modules/less": {
       "version": "3.9.0",
@@ -9474,12 +9583,7 @@
       "integrity": "sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==",
       "dev": true,
       "dependencies": {
-        "clone": "^2.1.2",
-        "errno": "^0.1.1",
-        "graceful-fs": "^4.1.2",
-        "mime": "^1.4.1",
-        "mkdirp": "^0.5.0",
-        "request": "^2.83.0"
+        "clone": "^2.1.2"
       },
       "bin": {
         "lessc": "bin/lessc"
@@ -9488,8 +9592,13 @@
         "node": ">=4"
       },
       "optionalDependencies": {
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
         "image-size": "~0.5.0",
+        "mime": "^1.4.1",
+        "mkdirp": "^0.5.0",
         "promise": "^7.1.1",
+        "request": "^2.83.0",
         "source-map": "~0.6.0"
       }
     },
@@ -9505,6 +9614,10 @@
       },
       "engines": {
         "node": ">= 4.8 < 5.0.0 || >= 5.10"
+      },
+      "peerDependencies": {
+        "less": "^2.3.1 || ^3.0.0",
+        "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/less-loader/node_modules/pify": {
@@ -9625,6 +9738,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-4.2.0.tgz",
       "integrity": "sha512-1dJ2ORJcdqbzxvzKM2ceqPBh4O6bbICJpB4dvSEUoMcb14s8MqQ/54zNPqekuN5yjGtxO3GUDTvZfQOQhwdqnA==",
+      "deprecated": "4.x is no longer supported. Please upgrade to 6.x or higher.",
       "dev": true,
       "dependencies": {
         "date-format": "^2.0.0",
@@ -9641,6 +9755,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -10147,6 +10262,9 @@
       },
       "engines": {
         "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.4.0"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -10288,6 +10406,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "dev": true,
       "dependencies": {
         "minimist": "0.0.8"
@@ -10441,21 +10560,46 @@
       "dev": true,
       "dependencies": {
         "filesize": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=2.0.0 <9.0.0"
       }
     },
     "node_modules/ngx-foundation": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/ngx-foundation/-/ngx-foundation-1.0.8.tgz",
       "integrity": "sha512-TEJDyVkagTR54nbA5zM0H6onCP/qP2PlWqHt39eZuNB4CmEyBa32ykj9NMY6S/o0jVCyT401oEcnhzCXHYOrig==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "@angular/common": ">=6.0.0",
+        "@angular/core": ">=6.0.0"
+      }
     },
     "node_modules/ngx-infinite-scroll": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/ngx-infinite-scroll/-/ngx-infinite-scroll-8.0.0.tgz",
       "integrity": "sha512-9KRCFAszLttd735CY1GbqtiVRdEvAGWUL8FQqD+iBGitbhgws4OZS+qdKIV+lrJzYXh+Y2XnOOSiUFADOo4+fQ==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "opencollective-postinstall": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@angular/common": ">= 8.0.0",
+        "@angular/core": ">= 8.0.0"
+      }
+    },
+    "node_modules/ngx-owl-carousel-o": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ngx-owl-carousel-o/-/ngx-owl-carousel-o-2.1.1.tgz",
+      "integrity": "sha512-1HRJdrOFvaol0yeVRpLC31fQhizb4eQHeKtLoWMj7VjlKh5WhZbrI7C3yIY0iTz8ZxCHZywspXFZH9dej7RjRQ==",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^8.0.0-rc.0 || ^8.0.0",
+        "@angular/core": "^8.0.0-rc.0 || ^8.0.0",
+        "rxjs": "^6.0.1"
       }
     },
     "node_modules/ngx-toastr": {
@@ -10464,6 +10608,11 @@
       "integrity": "sha512-DbLFkSZHsVPuuIIrsY1ziEhdkFUQ0V1yG1N0+1nKXGI5QBVesEDxLUVtntjzxJcWw/uUV+bKApo//tGHHORabQ==",
       "dependencies": {
         "tslib": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=8.0.0-0",
+        "@angular/core": ">=8.0.0-0",
+        "@angular/platform-browser": ">=8.0.0-0"
       }
     },
     "node_modules/nice-try": {
@@ -10520,6 +10669,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
       "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
+      "deprecated": "This module is not used anymore, npm uses minipass-fetch for its fetch implementation now",
       "dev": true,
       "dependencies": {
         "encoding": "^0.1.11",
@@ -11856,6 +12006,7 @@
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.4.2.tgz",
       "integrity": "sha512-zlIj64Cr6IOWP7RwxVeD8O4UskLYPoyIcg0HboWJL9T79F1F0VWtKkGTr/9GN6BKL+/Q/GmM7C9kFVCfDbP5sA==",
+      "deprecated": "We have news to share - Protractor is deprecated and will reach end-of-life by Summer 2023. To learn more and find out about other options please refer to this post on the Angular blog. Thank you for using and contributing to Protractor. https://goo.gle/state-of-e2e-in-angular",
       "dev": true,
       "dependencies": {
         "@types/q": "^0.0.32",
@@ -12098,6 +12249,7 @@
       "version": "14.4.1",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-14.4.1.tgz",
       "integrity": "sha512-+H0Gm84aXUvSLdSiDROtLlOofftClgw2TdceMvvCU9UvMryappoeS3+eOLfKvoy4sm8B8MWnYmPhWxVFudAOFQ==",
+      "deprecated": "< 19.4.0 is no longer supported",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -12306,6 +12458,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
@@ -12414,6 +12567,9 @@
       },
       "engines": {
         "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.3.0"
       }
     },
     "node_modules/rbush": {
@@ -12449,16 +12605,19 @@
       "dev": true,
       "dependencies": {
         "glob": "^7.1.1",
-        "graceful-fs": "^4.1.2",
         "json-parse-better-errors": "^1.0.1",
         "normalize-package-data": "^2.0.0",
         "slash": "^1.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.2"
       }
     },
     "node_modules/read-package-tree": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.2.tgz",
       "integrity": "sha512-rW3XWUUkhdKmN2JKB4FL563YAgtINifso5KShykufR03nJ5loGFlkUMe1g/yxmqX073SoYYTsgXu7XdDinKZuA==",
+      "deprecated": "The functionality that this package provided is now in @npmcli/arborist",
       "dev": true,
       "dependencies": {
         "debuglog": "^1.0.1",
@@ -12601,6 +12760,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
       "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
       "dev": true,
       "dependencies": {
         "debuglog": "^1.0.1",
@@ -12745,6 +12905,7 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -12844,6 +13005,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
     },
     "node_modules/restore-cursor": {
@@ -13063,6 +13225,9 @@
       },
       "engines": {
         "node": ">= 6.9.0 || >= 8.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/sass-loader/node_modules/pify": {
@@ -13312,6 +13477,9 @@
       "integrity": "sha1-0Kuf+8K51Yda+LAd7DYzl4RSW0Q=",
       "dependencies": {
         "daemon": ">=0.3.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/set-blocking": {
@@ -13791,6 +13959,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -13894,6 +14063,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
       "dependencies": {
         "atob": "^2.1.1",
@@ -13926,12 +14096,14 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true
     },
     "node_modules/sourcemap-codec": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
       "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
       "dev": true
     },
     "node_modules/spdx-correct": {
@@ -14001,6 +14173,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -14030,6 +14203,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -14051,6 +14225,9 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1 || ^2 || ^3 || ^4"
       }
     },
     "node_modules/splaytree": {
@@ -14142,6 +14319,9 @@
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.4"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.0.0"
       }
     },
     "node_modules/statuses": {
@@ -14196,6 +14376,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-1.0.5.tgz",
       "integrity": "sha512-iGVaMcyF5PcUY0cPbW3xFQUXnr9O4RZXNBBjhuLZgrjLO4XCLLGfx4T2sGqygSeylUjwgWRsnNbT9aV0Zb8AYw==",
+      "deprecated": "1.x is no longer supported. Please upgrade to 3.x or higher.",
       "dev": true,
       "dependencies": {
         "async": "^2.6.2",
@@ -14212,6 +14393,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -14819,6 +15001,9 @@
         "loader-utils": "^1.0.2",
         "lodash.clonedeep": "^4.5.0",
         "when": "~3.6.x"
+      },
+      "peerDependencies": {
+        "stylus": ">=0.52.4"
       }
     },
     "node_modules/stylus/node_modules/glob": {
@@ -15114,6 +15299,9 @@
       },
       "engines": {
         "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/source-map": {
@@ -15439,6 +15627,9 @@
       },
       "engines": {
         "node": ">=4.8.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev"
       }
     },
     "node_modules/tsutils": {
@@ -15448,6 +15639,9 @@
       "dev": true,
       "dependencies": {
         "tslib": "^1.8.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
       }
     },
     "node_modules/tty-browserify": {
@@ -15682,6 +15876,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -15781,6 +15976,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
       "dev": true
     },
     "node_modules/url": {
@@ -15856,6 +16052,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -16091,6 +16288,9 @@
       },
       "engines": {
         "node": ">= 6"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/webpack-dev-middleware/node_modules/mime": {
@@ -16147,12 +16347,16 @@
       },
       "engines": {
         "node": ">= 6.11.5"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/webpack-dev-server/node_modules/chokidar": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
       "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+      "deprecated": "Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies",
       "dev": true,
       "dependencies": {
         "anymatch": "^2.0.0",
@@ -16175,6 +16379,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -16255,6 +16460,9 @@
       },
       "engines": {
         "node": ">=4"
+      },
+      "peerDependencies": {
+        "webpack": "^1.12.11 || ~2 || ~3 || ~4"
       }
     },
     "node_modules/websocket-driver": {
@@ -16343,6 +16551,9 @@
       "dev": true,
       "dependencies": {
         "loader-utils": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": ">= 4"
       }
     },
     "node_modules/wrap-ansi": {
@@ -25468,6 +25679,14 @@
         "opencollective-postinstall": "^2.0.2"
       }
     },
+    "ngx-owl-carousel-o": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ngx-owl-carousel-o/-/ngx-owl-carousel-o-2.1.1.tgz",
+      "integrity": "sha512-1HRJdrOFvaol0yeVRpLC31fQhizb4eQHeKtLoWMj7VjlKh5WhZbrI7C3yIY0iTz8ZxCHZywspXFZH9dej7RjRQ==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "ngx-toastr": {
       "version": "11.3.3",
       "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-11.3.3.tgz",
@@ -26367,8 +26586,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
           "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -26911,8 +27129,7 @@
           "version": "8.7.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
           "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -28719,8 +28936,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.1.tgz",
           "integrity": "sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "ansi-regex": {
           "version": "5.0.1",
@@ -28906,8 +29122,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
           "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "postcss-value-parser": {
           "version": "4.2.0",
@@ -28962,8 +29177,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-html/-/stylelint-config-html-1.0.0.tgz",
       "integrity": "sha512-rKQUUWDpaYC7ybsS6tLxddjn6DxhjSIXybElSmcTyVQj3ExhmU3q+l41ktrlwHRyY0M5SkTkZiwngvYPYmsgSQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylelint-stylus": {
       "version": "0.16.1",

--- a/angular/package.json
+++ b/angular/package.json
@@ -46,6 +46,7 @@
     "leaflet.markercluster": "^1.4.1",
     "mapillary-js": "^4.1.0",
     "ng-tapis": "2.1.6",
+    "ngx-owl-carousel-o": "^2.1.1",
     "ngx-toastr": "^11.3.3",
     "patch-package": "^6.4.7",
     "rxjs": "~6.5.3",

--- a/angular/src/app/app.module.ts
+++ b/angular/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { ModalModule, BsDropdownModule, TooltipModule, TabsModule, PaginationModule } from 'ngx-foundation';
 import { FileSizeModule } from 'ngx-filesize';
 import { ApiModule } from 'ng-tapis';
+import { CarouselModule } from 'ngx-owl-carousel-o';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { MapComponent } from './components/map/map.component';
@@ -68,6 +69,7 @@ import { ModalStreetviewOrganizationComponent } from './components/modal-streetv
 import { StreetviewAssetDetailComponent } from './components/streetview-asset-detail/streetview-asset-detail.component';
 import { StreetviewFiltersComponent } from './components/streetview-filters/streetview-filters.component';
 import { ModalQuestionnaireViewerComponent } from './components/modal-questionnaire-viewer/modal-questionnaire-viewer.component';
+import { QuestionnaireDetailComponent } from './components/questionnaire-detail/questionnaire-detail.component';
 
 @NgModule({
   declarations: [
@@ -122,6 +124,7 @@ import { ModalQuestionnaireViewerComponent } from './components/modal-questionna
     StreetviewAssetDetailComponent,
     StreetviewFiltersComponent,
     ModalQuestionnaireViewerComponent,
+    QuestionnaireDetailComponent,
   ],
   imports: [
     CommonModule,
@@ -143,6 +146,7 @@ import { ModalQuestionnaireViewerComponent } from './components/modal-questionna
     ToastrModule.forRoot(),
     DragDropModule,
     PaginationModule.forRoot(),
+    CarouselModule,
   ],
   providers: [
     AuthService,

--- a/angular/src/app/components/asset-detail/asset-detail.component.html
+++ b/angular/src/app/components/asset-detail/asset-detail.component.html
@@ -13,44 +13,38 @@
         </div>
         <hr />
     </div>
-    <div class="cell medium-5 auto asset-detail-content">
+    <div class="cell medium-6 auto asset-detail-content">
         <img *ngIf="feature.featureType() === 'image'" [src]="featureSource" />
         <video *ngIf="feature.featureType() === 'video'" [src]="featureSource" controls width="100%"></video>
         <div style="position: relative" *ngIf="feature.featureType() === 'point_cloud'">
             <iframe class="e2e-iframe-trusted-src" [src]="safePointCloudUrl" style="width: 100%; height: 300px"> </iframe>
         </div>
+        <div *ngIf="feature.featureType() === 'questionnaire'">
+            <app-questionnaire-detail [feature]="feature" [featureSource]="featureSource"></app-questionnaire-detail>
+        </div>
     </div>
     <div class="cell medium-1 text-center asset-detail-action">
-        <div *ngIf="feature.featureType() === 'questionnaire'">
-            <button class="button small" (click)="openQuestionnaireModal(feature)">View Questionnaire</button>
-        </div>
         <div *ngIf="feature.featureType() === 'image'">
             <a [href]="featureSource" download="feature-{{ feature.id }}.jpeg">
                 <button class="button small">Download</button>
             </a>
         </div>
-        <div class="cell medium-1 text-center asset-detail-action">
-            <div *ngIf="feature.featureType() === 'image'">
-                <a [href]="featureSource" download="feature-{{ feature.id }}.jpeg">
-                    <button class="button small">Download</button>
-                </a>
-            </div>
-            <div *ngIf="feature.featureType() === 'point_cloud'">
-                <a [href]="featureSource + '/index.html'" target="_blank">
-                    <button class="button small">View</button>
-                </a>
-            </div>
-            <div *ngIf="!feature.assets.length" class="text-center">
-                <div data-alert class="alert-box secondary">Feature has no asset.</div>
-                <button class="button expanded hollow" (click)="openFileBrowserModal()" *ngIf="!isPublicView">
-                    Add asset from DesignSafe
-                </button>
-            </div>
-            <hr />
+        <div *ngIf="feature.featureType() === 'point_cloud'">
+            <a [href]="featureSource + '/index.html'" target="_blank">
+                <button class="button small">View</button>
+            </a>
         </div>
-        <div class="cell medium-5 asset-detail-content">
-            <app-feature-metadata [feature]="feature"></app-feature-metadata>
-            <app-feature-geometry [feature]="feature"></app-feature-geometry>
+        <div *ngIf="feature.featureType() === 'questionnaire'">
+            <button class="button small" (click)="openQuestionnaireModal(feature)">View Questionnaire</button>
         </div>
+        <div *ngIf="!feature.assets.length" class="text-center">
+            <div data-alert class="alert-box secondary">Feature has no asset.</div>
+            <button class="button expanded hollow" (click)="openFileBrowserModal()" *ngIf="!isPublicView">Add asset from DesignSafe</button>
+        </div>
+        <hr />
+    </div>
+    <div class="cell medium-5 asset-detail-content">
+        <app-feature-metadata [feature]="feature"></app-feature-metadata>
+        <app-feature-geometry [feature]="feature"></app-feature-geometry>
     </div>
 </div>

--- a/angular/src/app/components/feature-metadata/feature-metadata.component.html
+++ b/angular/src/app/components/feature-metadata/feature-metadata.component.html
@@ -2,12 +2,14 @@
     <h6 class="">Metadata</h6>
 </div>
 <div class="grid-x grid-margin-x kv-table" *ngFor="let item of feature.properties | keyvalue">
-    <div class="cell small-4 text-left break">
-        <b>
-            <span> {{ item.key | titlecase }} </span></b
-        >
-    </div>
-    <div class="cell small-8 text-left break">
-        <code>{{ item.value | json }}</code>
-    </div>
+    <ng-container *ngIf="!item.key.startsWith('_hazmapper')">
+        <div class="cell small-4 text-left break">
+            <b>
+                <span>{{ item.key | titlecase }}</span>
+            </b>
+        </div>
+        <div class="cell small-8 text-left break">
+            <code>{{ item.value | json }}</code>
+        </div>
+    </ng-container>
 </div>

--- a/angular/src/app/components/modal-questionnaire-viewer/modal-questionnaire-viewer.component.ts
+++ b/angular/src/app/components/modal-questionnaire-viewer/modal-questionnaire-viewer.component.ts
@@ -19,7 +19,8 @@ export class ModalQuestionnaireViewerComponent implements OnInit {
   ngOnInit() {
     this.projectService.activeProject.subscribe((p) => {
       this.geoDataService.getFeatureAssetSource(this.feature, '/questionnaire.rq').subscribe((featureSource: any) => {
-        const questionnaire = QuestionnaireBuilder.renderQuestionnaire(featureSource);
+        const asset_path = this.geoDataService.getFeatureAssetSourcePath(this.feature);
+        const questionnaire = QuestionnaireBuilder.renderQuestionnaire(featureSource, asset_path);
         $('#questionnaire-view').after(questionnaire); // Insert new elements after <img>
       });
     });

--- a/angular/src/app/components/questionnaire-detail/questionnaire-detail.component.html
+++ b/angular/src/app/components/questionnaire-detail/questionnaire-detail.component.html
@@ -1,0 +1,10 @@
+<owl-carousel-o [options]="customOptions">
+    <ng-template carouselSlide *ngFor="let asset of assetImages">
+        <div class="slide">
+            <img [src]="asset.previewPath" [alt]="asset.filename" />
+            <div class="caption">
+                <h6>{{ asset.filename }}</h6>
+            </div>
+        </div>
+    </ng-template>
+</owl-carousel-o>

--- a/angular/src/app/components/questionnaire-detail/questionnaire-detail.component.spec.ts
+++ b/angular/src/app/components/questionnaire-detail/questionnaire-detail.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { QuestionnaireDetailComponent } from './questionnaire-detail.component';
+
+describe('QuestionnaireDetailComponent', () => {
+  let component: QuestionnaireDetailComponent;
+  let fixture: ComponentFixture<QuestionnaireDetailComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [QuestionnaireDetailComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(QuestionnaireDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular/src/app/components/questionnaire-detail/questionnaire-detail.component.styl
+++ b/angular/src/app/components/questionnaire-detail/questionnaire-detail.component.styl
@@ -1,0 +1,4 @@
+@import "../../../variables.styl"
+  .caption
+    color #1f5c7a
+    font-size 0.8em

--- a/angular/src/app/components/questionnaire-detail/questionnaire-detail.component.ts
+++ b/angular/src/app/components/questionnaire-detail/questionnaire-detail.component.ts
@@ -1,0 +1,49 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { OwlOptions } from 'ngx-owl-carousel-o';
+import { Feature } from '../../models/models';
+import { QuestionnaireAsset } from '../../models/questionnaire';
+
+@Component({
+  selector: 'app-questionnaire-detail',
+  templateUrl: './questionnaire-detail.component.html',
+  styleUrls: ['./questionnaire-detail.component.styl'],
+  providers: [],
+})
+export class QuestionnaireDetailComponent implements OnInit {
+  @Input() feature: Feature;
+  @Input() featureSource: string;
+  assetImages: Array<QuestionnaireAsset>;
+  customOptions: OwlOptions = {
+    items: 1,
+    loop: false,
+    autoplay: false,
+    nav: true,
+    dots: false,
+    responsive: {},
+    mouseDrag: true,
+    touchDrag: true,
+    pullDrag: true,
+    center: false,
+  };
+
+  constructor() {}
+
+  ngOnInit() {
+    // Retrieve asset images and map them to a new array with proper paths to full/preview images
+    this.assetImages = this.feature.properties._hazmapper.questionnaire.assets.map((asset) => {
+      const pathToFullImage = this.featureSource + '/' + asset.filename;
+      const fileExtension = pathToFullImage.substring(pathToFullImage.lastIndexOf('.'));
+      const pathWithoutExtension = pathToFullImage.substring(0, pathToFullImage.lastIndexOf('.'));
+      const pathToPreviewImage = `${pathWithoutExtension}.preview${fileExtension}`;
+
+      const filename = asset.filename.split('.');
+      filename.splice(filename.length - 1, 0, 'preview');
+      return {
+        filename: asset.filename,
+        coordinates: asset.coordinates,
+        path: pathToFullImage,
+        previewPath: pathToPreviewImage,
+      };
+    });
+  }
+}

--- a/angular/src/app/models/questionnaire.ts
+++ b/angular/src/app/models/questionnaire.ts
@@ -1,0 +1,6 @@
+export interface QuestionnaireAsset {
+  filename: string;
+  coordinates: any;
+  path: string;
+  previewPath: string;
+}

--- a/angular/src/app/services/geo-data.service.ts
+++ b/angular/src/app/services/geo-data.service.ts
@@ -536,10 +536,31 @@ export class GeoDataService {
     });
   }
 
-  getFeatureAssetSource(feature: Feature, optionalPath = null) {
+  /**
+   * Get the source path for a feature asset.
+   *
+   * @param feature - The feature for which to get the source path (assumes that there is a single asset).
+   * @param optionalPath - An optional additional path to append to the source path.
+   * @returns The source path for the feature asset.
+   */
+  getFeatureAssetSourcePath(feature: Feature, optionalPath: string | null = null): string {
     const baseFeatureSource = this.envService.apiUrl + '/assets/' + feature.assets[0].path;
-    const featureSource = optionalPath ? baseFeatureSource + optionalPath : baseFeatureSource;
-    return this.http.get(featureSource, { headers: { 'content-type': 'application/json' } });
+    const featureSourcePath = optionalPath ? baseFeatureSource + optionalPath : baseFeatureSource;
+    return featureSourcePath;
+  }
+
+  /**
+   * Get the feature source
+   *
+   * Note: only supports json
+   *
+   * @param feature - The feature for which to get the source path (assumes that there is a single asset).
+   * @param optionalPath - An optional additional path to append to the source path.
+   * @returns The source path for the feature asset.
+   */
+  getFeatureAssetSource(feature: Feature, optionalPath = null) {
+    const featureSourcePath = this.getFeatureAssetSourcePath(feature, optionalPath);
+    return this.http.get(featureSourcePath, { headers: { 'content-type': 'application/json' } });
   }
 
   public get qmsSearchResults(): Observable<Array<any>> {

--- a/angular/src/app/utils/questionnaireBuilder.ts
+++ b/angular/src/app/utils/questionnaireBuilder.ts
@@ -560,7 +560,7 @@ QuestionnaireBuilder.ASSET_EMBEDDING_DEFAULT = true;
 QuestionnaireBuilder.ALLOW_BACK_DEFAULT = true;
 QuestionnaireBuilder.EDITABLE_DEFAULT = false;
 
-QuestionnaireBuilder.renderQuestionnaire = function(questionnaire_json) {
+QuestionnaireBuilder.renderQuestionnaire = function(questionnaire_json, asset_path) {
   /** Method to generate read only questionnaire for viewing in DesignSafe
    *
    * Takes a json object containing questionnaire structure and responses
@@ -569,7 +569,7 @@ QuestionnaireBuilder.renderQuestionnaire = function(questionnaire_json) {
    *
    * **/
 
-  const questionnaire = new Questionnaire(questionnaire_json);
+  const questionnaire = new Questionnaire(questionnaire_json, asset_path);
   if (questionnaire) { return questionnaire.renderView(); }
 };
 
@@ -583,10 +583,17 @@ class Questionnaire {
   MAP_ADDED_TO_PANEL;
   embedded_asset_map;
   embedded_asset_uuids;
+  asset_path;
 
-  constructor(metadata) {
-    // add metadata
+  constructor(metadata, asset_path) {
+
+
     const qnaire = this;
+
+    // add base path to assets
+    qnaire.asset_path = asset_path
+
+    // add metadata
     for (const property in metadata) { qnaire[property] = metadata[property]; }
     qnaire.num_questions = 0;
 
@@ -901,7 +908,7 @@ class Question {
   parent_question;
   decline;
   responseStrings;
-  assetUuids;
+  assets;
 
   constructor(
     metadata,
@@ -1075,24 +1082,16 @@ class Question {
   /** !!!!! This method will need to be updated to get embedded assets to work in designsafe !!!!!  **/
   addEmbeddedAssets(container) {
     const question = this;
-
-    if (question.hasOwnProperty('assetUuids')) {
-      if (question.assetUuids) {
-        if (question.assetUuids.length) {
-          for (const uuid of question.assetUuids) {
-            // let asset = Assets.getAsset(uuid);
-
-            // TODO modify this url path to work with DesingSafe
-            // let url =
-            //   Parameters.deployment === 'live'
-            //     ? 'https://rapid.apl.uw.edu' + asset.file_url
-            //     : 'https://rapid2.apl.uw.edu' + asset.file_url;
+    if (question.hasOwnProperty('assets')) {
+      if (question.assets) {
+        if (question.assets.length) {
+          for (const asset of question.assets) {
+            const url = question.parent_template.asset_path + '/' + asset.filename;
 
             DOM.new({
               tag: 'img',
               class: 'embeddedAssetViewImg',
-              // src: url,
-              src: 'https://google.com',
+              src: url,
               parent: container,
               children: [
                 {
@@ -1610,7 +1609,7 @@ class SingleAnswer extends Question {
      * has been added
      * **/
 
-    // question.addEmbeddedAssets(container)
+    question.addEmbeddedAssets(container)
   }
 }
 class MultiAnswer extends SingleAnswer {
@@ -1727,7 +1726,7 @@ class MultiAnswer extends SingleAnswer {
       $(view).insertAfter($(option_element));
     }
 
-    // question.addEmbeddedAssets(container)
+    question.addEmbeddedAssets(container)
   }
 
   getResponse(viewer_option) {
@@ -2165,7 +2164,7 @@ class MultiText extends Question {
       i++;
     }
 
-    // question.addEmbeddedAssets(container)
+    question.addEmbeddedAssets(container)
 
     if (!question.is_sub_question) {
       $(view).appendTo($(container));
@@ -2400,7 +2399,7 @@ class NumberField extends Question {
       parent: item,
     });
 
-    // question.addEmbeddedAssets(container)
+    question.addEmbeddedAssets(container)
 
     if (!question.is_sub_question) {
       $(view).appendTo($(container));
@@ -2737,7 +2736,7 @@ class LocationField extends Question {
       question.responseStrings[2]
     );
 
-    // question.addEmbeddedAssets(container)
+    question.addEmbeddedAssets(container)
   }
 }
 class RangeAnswer extends Question {
@@ -2990,7 +2989,7 @@ class RangeAnswer extends Question {
       'optionSelected'
     );
 
-    // question.addEmbeddedAssets(container)
+    question.addEmbeddedAssets(container)
 
     if (!question.is_sub_question) {
       $(view).appendTo($(container));
@@ -3296,7 +3295,7 @@ class Matrix extends Question {
       }
     }
 
-    // question.addEmbeddedAssets(container)
+    question.addEmbeddedAssets(container)
 
     $(view).appendTo(container);
   }
@@ -3403,7 +3402,7 @@ class TextPage extends Question {
     const question = this;
     const view = $(this.read_only_view);
     $(view).find('p.questionNumber').html(question.scroll_label);
-    // question.addEmbeddedAssets(container)
+    question.addEmbeddedAssets(container)
     $(view).appendTo(container);
   }
 }

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -3,7 +3,9 @@
 // The list of file replacements can be found in `angular.json`.
 
 import { jwt as devJWT } from './jwt';
+import { dev_env as devEnv } from './jwt';
 import { EnvironmentType } from '../environments/environmentType';
+console.log(devEnv);
 
 export interface AppEnvironment {
   jwt?: string;
@@ -12,7 +14,7 @@ export interface AppEnvironment {
 }
 
 export const environment: AppEnvironment = {
-  backend: EnvironmentType.Local,
+  backend: devEnv,
   jwt: devJWT,
   production: false,
 };

--- a/angular/src/styles.styl
+++ b/angular/src/styles.styl
@@ -1,4 +1,4 @@
-// You can add global styles to this file, and also import other style files 
+// You can add global styles to this file, and also import other style files
 @import "~leaflet/dist/leaflet.css"
 @import "~@fortawesome/fontawesome-free/css/all.css"
 @import "~foundation-sites/dist/css/foundation.css"
@@ -7,8 +7,8 @@
 @import "~ngx-foundation/dist/css/ngx-foundation.css"
 @import '~ngx-toastr/toastr.css'
 @import url('https://unpkg.com/mapillary-js@2.18.0/dist/mapillary.min.css')
-
-
+@import '~ngx-owl-carousel-o/lib/styles/prebuilt-themes/owl.carousel.css'
+@import '~ngx-owl-carousel-o/lib/styles/prebuilt-themes/owl.theme.default.css'
 
 html
 body
@@ -17,11 +17,11 @@ h2
 h3
 h4
 h5
-h6 
+h6
     font-family Raleway
 
 
-.tooltip 
+.tooltip
   word-wrap break-word
 
 

--- a/angular/tsconfig.json
+++ b/angular/tsconfig.json
@@ -11,7 +11,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2020",
     "typeRoots": [
       "node_modules/@types",
       "src/app/typings"


### PR DESCRIPTION
## Overview: ##

A small QoL tweak to avoid committing incorrect backend environment during development.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* None

## Summary of Changes: ##

Changed the assignment of the angular client backend to use a constant exported form the `jwt.ts` file.

## Testing Steps: ##
1. Add these lines to your `/hazmapper/angular/src/environments/jwt.ts` file:
```
import { EnvironmentType } from '../environments/environmentType';
export const dev_env = EnvironmentType.Staging;      # Local, Staging, Production
```
2. Run the project using the correct start command (`npm run start` or `npm rn start:locally` if set to `Local`).
3. Open browser to project URL (`localhost:4200` or `hazmapper.local:4200`) and use.

## UI Photos:

## Notes: ##
