### PR TITLE
task/WG-140: add app information to request for analytics-related logging

### DIFF
--- a/angular/src/app/app.interceptors.ts
+++ b/angular/src/app/app.interceptors.ts
@@ -54,6 +54,16 @@ export class JwtInterceptor implements HttpInterceptor {
       });
     }
 
+    if(request.url.indexOf(this.envService.apiUrl) > -1) {
+      // Add information about what app is making the request
+      request = request.clone({
+        setHeaders: {
+          'X-Geoapi-Application': 'hazmapper',
+        },
+      });
+    }
+
+
     if (
       request.url.indexOf(this.envService.streetviewEnv.mapillary.apiUrl) > -1 &&
       !(request.url.indexOf(this.envService.streetviewEnv.mapillary.tokenUrl) > -1)

--- a/angular/src/app/app.interceptors.ts
+++ b/angular/src/app/app.interceptors.ts
@@ -54,7 +54,7 @@ export class JwtInterceptor implements HttpInterceptor {
       });
     }
 
-    if(request.url.indexOf(this.envService.apiUrl) > -1) {
+    if (request.url.indexOf(this.envService.apiUrl) > -1) {
       // Add information about what app is making the request
       request = request.clone({
         setHeaders: {
@@ -62,7 +62,6 @@ export class JwtInterceptor implements HttpInterceptor {
         },
       });
     }
-
 
     if (
       request.url.indexOf(this.envService.streetviewEnv.mapillary.apiUrl) > -1 &&


### PR DESCRIPTION
## Overview: ##

This PR adds the application information (i.e. "taggit", "hazmapper") to the request header to be used by the backend for analytics-related logging. See https://github.com/TACC-Cloud/geoapi/pull/161 for more details.

## Related Jira tickets: ##

* [WG-140](https://jira.tacc.utexas.edu/browse/WG-140)

## Summary of Changes: ##

## Testing Steps: ##
See https://github.com/TACC-Cloud/geoapi/pull/161