### PR TITLE
task/WG-172: stop "View Questionnaire" button from being pushed multiple times

### DIFF
--- a/angular/src/app/components/asset-detail/asset-detail.component.styl
+++ b/angular/src/app/components/asset-detail/asset-detail.component.styl
@@ -10,7 +10,7 @@
       display flex
       align-items center
   position fixed
-  z-index 5000
+  z-index 900
   width 35%
   min-width 250px
   max-width 400px


### PR DESCRIPTION
## Overview: ##

With the questionnaire modal open, you could still click "View Questionnaire" button multiple times. This caused multiple modals to be opened on top of each other and a darkening of the screen. The issue was that the right panel (containing the "View Questionnaire" button) had a z-index value higher than the modal's z-index.  This is fixed in this PR.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-172](https://jira.tacc.utexas.edu/browse/WG-172)

## Summary of Changes: ##

## Testing Steps: ##
0. (optional) use staging environment for backend (i.e. edit `angular/src/environments/environment.ts` to use `backend: EnvronmentType.Staging`) 
1. Choose a map with a questionnaire.
2. Ensure you can no longer click View Questionnaire multiple times.
