### PR TITLE
task/WG-91-Allow non-persistent tile layer adjustments in public hazmapper maps

### DIFF
--- a/angular/src/app/components/dock/dock.component.html
+++ b/angular/src/app/components/dock/dock.component.html
@@ -20,7 +20,7 @@
                 </div>
             </button>
         </div>
-        <div class="dock-button" [ngClass]="{ active: panelsDisplay.layers }" *ngIf="!isPublicView">
+        <div class="dock-button" [ngClass]="{ active: panelsDisplay.layers }">
             <button (click)="showPanel('layers')" [disabled]="!activeProject">
                 <div>
                     <img class="dock-button-icon" src="assets/layers.png" width="32px" />
@@ -68,7 +68,7 @@
     </div>
     <div class="cell auto dock-panel">
         <app-assets-panel *ngIf="panelsDisplay.assets" [isPublicView]="isPublicView"></app-assets-panel>
-        <app-layers-panel *ngIf="panelsDisplay.layers"></app-layers-panel>
+        <app-layers-panel *ngIf="panelsDisplay.layers" [isPublicView]="isPublicView"></app-layers-panel>
         <app-filters-panel *ngIf="panelsDisplay.filters"></app-filters-panel>
         <app-measure-panel *ngIf="panelsDisplay.measure"></app-measure-panel>
         <app-settings-panel *ngIf="panelsDisplay.settings"></app-settings-panel>

--- a/angular/src/app/components/layers-panel/layers-panel.component.html
+++ b/angular/src/app/components/layers-panel/layers-panel.component.html
@@ -123,11 +123,7 @@
                     <span class="overlay-label"> {{ ov.label }} </span>
                 </div>
                 <div class="cell grid-x auto align-right">
-                    <button 
-                        class="button hollow tiny alert button-no-margin" 
-                        (click)="deleteOverlay(ov)" 
-                        [disabled]="isPublicView"
-                    >
+                    <button class="button hollow tiny alert button-no-margin" (click)="deleteOverlay(ov)" [disabled]="isPublicView">
                         <i class="fa fa-trash"></i>
                     </button>
                 </div>

--- a/angular/src/app/components/layers-panel/layers-panel.component.html
+++ b/angular/src/app/components/layers-panel/layers-panel.component.html
@@ -110,7 +110,7 @@
         </div>
         <hr />
 
-        <h6 *ngIf="!isPublicView">Overlays</h6>
+        <h6>Overlays</h6>
         <button class="button expanded hollow tiny success" (click)="openCreateOverlayModal()" *ngIf="!isPublicView">
             <i class="fa fa-plus"></i>
         </button>

--- a/angular/src/app/components/layers-panel/layers-panel.component.html
+++ b/angular/src/app/components/layers-panel/layers-panel.component.html
@@ -2,7 +2,7 @@
     <div class="dock-panel-content">
         <p class="dock-panel-title">Layers</p>
         <h6>Tile Layers</h6>
-        <button class="button expanded hollow tiny success" (click)="openCreateTileServerModal()">
+        <button class="button expanded hollow tiny success" (click)="openCreateTileServerModal()" *ngIf="!isPublicView">
             <i class="fa fa-plus"></i>
         </button>
         <div #cdkList cdkDropList class="tile-servers-list" (cdkDropListDropped)="drop($event)">
@@ -35,6 +35,7 @@
                                 (blur)="updateName(activeText.value, ts)"
                                 (keyup.enter)="updateName(activeText.value, ts)"
                                 [value]="ts.name"
+                                [readOnly]="isPublicView"
                             />
                             <div
                                 id="tile-server-name"
@@ -53,7 +54,7 @@
                     </div>
 
                     <div class="cell small-4 grid-x tile-server-right">
-                        <button class="button secondary clear edit-buttons">
+                        <button class="button secondary clear edit-buttons" *ngIf="!isPublicView">
                             <i class="fas fa-edit edit-button" (click)="showInput(ts, true)" *ngIf="!ts.uiOptions.showInput"></i>
                             <i class="fas fa-check edit-button" (click)="showInput(ts, false)" *ngIf="ts.uiOptions.showInput"></i>
                         </button>
@@ -63,6 +64,7 @@
                         <button
                             class="button secondary clear button-no-margin delete-button"
                             (click)="openDeleteTileServerModal(deleteTiles)"
+                            *ngIf="!isPublicView"
                         >
                             <i class="fa fa-trash"></i>
                         </button>
@@ -95,7 +97,7 @@
             </div>
         </div>
 
-        <div *ngIf="dirtyOptions" class="tile-server-dirty-options">
+        <div *ngIf="dirtyOptions && !isPublicView" class="tile-server-dirty-options">
             <i class="tile-server-dirty-options-warning">
                 Layer options have been changed!
                 <br />
@@ -103,13 +105,13 @@
             </i>
         </div>
 
-        <div class="tile-server-save-button">
+        <div *ngIf="dirtyOptions && !isPublicView" class="tile-server-save-button">
             <button class="button small success" [disabled]="!dirtyOptions" (click)="saveTileOptions()">Save Layer Options</button>
         </div>
         <hr />
 
-        <h6>Overlays</h6>
-        <button class="button expanded hollow tiny success" (click)="openCreateOverlayModal()">
+        <h6 *ngIf="!isPublicView">Overlays</h6>
+        <button class="button expanded hollow tiny success" (click)="openCreateOverlayModal()" *ngIf="!isPublicView">
             <i class="fa fa-plus"></i>
         </button>
         <div *ngFor="let ov of overlays" class="overlay">
@@ -121,7 +123,11 @@
                     <span class="overlay-label"> {{ ov.label }} </span>
                 </div>
                 <div class="cell grid-x auto align-right">
-                    <button class="button hollow tiny alert button-no-margin" (click)="deleteOverlay(ov)">
+                    <button 
+                        class="button hollow tiny alert button-no-margin" 
+                        (click)="deleteOverlay(ov)" 
+                        [disabled]="isPublicView"
+                    >
                         <i class="fa fa-trash"></i>
                     </button>
                 </div>

--- a/angular/src/app/components/layers-panel/layers-panel.component.ts
+++ b/angular/src/app/components/layers-panel/layers-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ElementRef, ViewChildren, QueryList, TemplateRef, OnDestroy } from '@angular/core';
+import { Component, OnInit, ElementRef, ViewChildren, QueryList, TemplateRef, OnDestroy, Input } from '@angular/core';
 import { GeoDataService } from '../../services/geo-data.service';
 import { Overlay, Project, TileServer } from '../../models/models';
 import { BsModalRef, BsModalService } from 'ngx-foundation';
@@ -17,6 +17,7 @@ import { Subscription } from 'rxjs';
 })
 export class LayersPanelComponent implements OnInit, OnDestroy {
   @ViewChildren('activeText') activeInputs: QueryList<ElementRef>;
+  @Input() isPublicView = false;
 
   dragHeight: number;
   releaseHeight: number;


### PR DESCRIPTION
## Overview: ##
During the RAPID webinar, users wanted to be able to tweak public map opacity without making changes to the map.

also from Karen (https://designsafe-ci.slack.com/archives/C057MKDUZFS/p1683657846684769?thread_ts=1683649659.461539&cid=C057MKDUZFS):

 It may also be helpful to keep some format of the layers option so users can still toggle between the satellite view and the map view. That way they can see what an area looked like before the event?
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-91](https://jira.tacc.utexas.edu/browse/WG-91)

## Summary of Changes: ##

- Project Owners will still be able to add tile layers, add overlays, edit tile layer names, change opacity, delete tile layers and delete overlays.
- However, now when project owners make their maps "public", the guest/user will be able to:
       1. See the Layers Option
       2. Tweak the opacity of a tile layer
       3. Toggle between tile layers (for example: toggling between Satellite view and the Roads view)
       4. Guests/users will not be able to delete or save layer changes (by design). 

## Testing Steps: ##
1. Go to geoapi repo and run 'make start'
2. Go to hazmapper repo and run 'npm run start'
3. Navigate to localhost:4200 and pick a project
4. Make the map "public" if it's not already, and open public map in another tab.
5. Compare the view that the project owner or co-owner can see (non-public) versus the public view of the map.
6. See screenshots below for comparison

## UI Photos:
**Project Owner/Co-Owner view is unchanged (non-public view)**
<img width="329" alt="Screenshot 2023-11-30 at 1 16 24 PM" src="https://github.com/TACC-Cloud/hazmapper/assets/50084480/3571abd1-6e8f-455f-8346-5656246c2b9d">
<br>
**Here is Option 1 for the public view (notice buttons are disabled, but not hidden from view)**
![Option1](https://github.com/TACC-Cloud/hazmapper/assets/50084480/6c9c9a29-afbd-4254-8640-754b7c483641)
<br>
**Here is Option 2 for the public view (notice buttons are hidden/not rendered)**
**If this option is picked I need to add back the 'Overlays' title**
![Option2](https://github.com/TACC-Cloud/hazmapper/assets/50084480/d6d5857f-f733-4d0b-8176-753c39d9805e)
<br> Let me know which option y'all prefer

## Notes: ##
I made it so that the 'Save Layer Options' button is only rendered when there's a change/save opportunity. Otherwise the button is not rendered, until it needs to be (this is only in the non-public view, in the public view the 'Save Layer Options' button is never rendered, by design).