### PR TITLE
Task/wg 174 & 175 improve right panel questionnaire pic scroll and metadata

### DIFF
--- a/angular/src/app/components/asset-detail/asset-detail.component.html
+++ b/angular/src/app/components/asset-detail/asset-detail.component.html
@@ -43,8 +43,10 @@
         </div>
         <hr />
     </div>
-    <div class="cell medium-5 asset-detail-content">
-        <app-feature-metadata [feature]="feature"></app-feature-metadata>
-        <app-feature-geometry [feature]="feature"></app-feature-geometry>
+    <div *ngIf="feature.assets[0].asset_type !== 'questionnaire'">
+        <div class="cell medium-5 asset-detail-content">
+            <app-feature-metadata [feature]="feature"></app-feature-metadata>
+            <app-feature-geometry [feature]="feature"></app-feature-geometry>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
## Overview: ##
Hide metadata and improve the scrolling of images included with a questionnaire. 

## PR Status: ##
( See note to decide if this is WIP or Ready)
* [] Ready.
* [ X ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-174](https://jira.tacc.utexas.edu/browse/WG-174)
* [WG-175](https://jira.tacc.utexas.edu/browse/WG-175)

## Summary of Changes: ##

Added conditional statement to html template so that if the feature asset is of type questionnaire, it will not display the metadata cells in the right hand detail. 
This removal of metadata gives space for the pictures included with a questionnaire and the next/previous buttons  so that they no longer get hidden depending on the size of the screen. 

## Testing Steps: ##
1. Open a questionnaire on a map
2. Ensure that the metadata cells are no longer there
3. Open a different type of asset that isn't a questionnaire
4. Ensure that the metadata cells are still there. 

## UI Photos:
![Screenshot 2023-11-30 at 5 31 53 PM](https://github.com/TACC-Cloud/hazmapper/assets/96220951/d76dec80-075d-4b26-9349-1217c3220bb3)

Small screens no longer push up the removed metadata cells and now no longer hide the carousel previous and next buttons.
![Screenshot 2023-11-30 at 5 32 14 PM](https://github.com/TACC-Cloud/hazmapper/assets/96220951/9595018e-0bd1-42ed-9dbb-cc1f41de3f22)

## Notes: ##

I may need to wait for the fix for [WG-188](https://jira.tacc.utexas.edu/browse/WG-188). Sometimes, a questionnaire not having any assets crashes the ability to see images for a questionnaire in the detail for all questionnaires. 

Have to stop and restart containers to get the carousel back up again and avoid questionnaires that don't have assets to see questionnaire images in the detail view again.