### PR TITLE
task/WG-191: do not use headers for analytics information due to WG-191

### DIFF
--- a/angular/src/app/app.interceptors.ts
+++ b/angular/src/app/app.interceptors.ts
@@ -41,7 +41,7 @@ export class JwtInterceptor implements HttpInterceptor {
     if (request.url.indexOf(this.envService.apiUrl) > -1) {
       // Add information about what app is making the request
 
-      //Disabling custom headers due to https://tacc-main.atlassian.net/browse/WG-191
+      // Disabling custom headers due to https://tacc-main.atlassian.net/browse/WG-191
       // and using additional query params
       let analytics_params = {};
 
@@ -71,9 +71,9 @@ export class JwtInterceptor implements HttpInterceptor {
         */
         analytics_params = { ...analytics_params, guest_uuid: guestUuid };
       }
-      /* Send analytics-related params to projects endpoint only (until we use headers again in https://tacc-main.atlassian.net/browse/WG-192) */
+      /* Send analytics-related params to projects endpoint only (until we use headers
+        again in https://tacc-main.atlassian.net/browse/WG-192) */
       if (this.isProjectFeaturesRequest(request)) {
-        debugger;
         // Clone the request and add query parameters
         request = request.clone({
           setParams: { ...request.params, ...analytics_params },

--- a/angular/src/app/app.interceptors.ts
+++ b/angular/src/app/app.interceptors.ts
@@ -48,7 +48,7 @@ export class JwtInterceptor implements HttpInterceptor {
 
       // for guest users, add a unique id
       if (!this.authSvc.isLoggedIn()) {
-        // Get (or create of needed) the guestUserID in local storage
+        // Get (or create if needed) the guestUserID in local storage
         let guestUuid = localStorage.getItem('guestUuid');
 
         if (!guestUuid) {

--- a/angular/src/app/app.interceptors.ts
+++ b/angular/src/app/app.interceptors.ts
@@ -41,15 +41,8 @@ export class JwtInterceptor implements HttpInterceptor {
     if (request.url.indexOf(this.envService.apiUrl) > -1) {
       // Add information about what app is making the request
 
-      // Disabling custom headers due to https://tacc-main.atlassian.net/browse/WG-191
-      // and using additional query params
+      // Using query params instead of custom headers due to https://tacc-main.atlassian.net/browse/WG-191
       let analytics_params = {};
-
-      /*request = request.clone({
-        setHeaders: {
-          'X-Geoapi-Application': 'hazmapper',
-        },
-      });*/
 
       analytics_params = { ...analytics_params, application: 'hazmapper' };
 
@@ -62,13 +55,7 @@ export class JwtInterceptor implements HttpInterceptor {
           guestUuid = uuidv4();
           localStorage.setItem('guestUuid', guestUuid);
         }
-        /*Disabling custom headers due to https://tacc-main.atlassian.net/browse/WG-191
-        request = request.clone({
-          setHeaders: {
-            'X-Guest-UUID': guestUuid,
-          },
-        });
-        */
+
         analytics_params = { ...analytics_params, guest_uuid: guestUuid };
       }
       /* Send analytics-related params to projects endpoint only (until we use headers


### PR DESCRIPTION
## Overview: ##

Disable added headers and use query params on single route instead. Headers can't be used due to https://tacc-main.atlassian.net/browse/WG-191 . The use of headers is left in code but commented out; to be re-used in WG-192 when we start using Taips V3.

See https://github.com/TACC-Cloud/geoapi/pull/161 for more details.

## Related Jira tickets: ##

* [WG-140](https://tacc-main.atlassian.net/browse/WG-140)
* [WG-191](https://tacc-main.atlassian.net/browse/WG-191)

## Testing Steps: ##
See https://github.com/TACC-Cloud/geoapi/pull/161