### PR TITLE
task/WG-215: addressing postcss vulnerability

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -13,7 +13,7 @@
                 "@babel/preset-typescript": "^7.21.0",
                 "@changey/react-leaflet-markercluster": "^4.0.0-rc1",
                 "@reduxjs/toolkit": "^1.8.4",
-                "@tacc/core-styles": "^2.22.6",
+                "@tacc/core-styles": "^2.23.1",
                 "@testing-library/react": "^13.4.0",
                 "@types/leaflet.markercluster": "^1.5.1",
                 "axios": "^1.6.2",
@@ -2975,9 +2975,9 @@
             }
         },
         "node_modules/@tacc/core-styles": {
-            "version": "2.23.0",
-            "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.23.0.tgz",
-            "integrity": "sha512-RDPDHn9Bd+EPqgxaaF0k4kV+Mgk0plC3ngyfQeaUpEleOfi6wSiBIZOvzZqqWhLQtEKdf6QZ4tFT0EUsLF1Akg==",
+            "version": "2.23.1",
+            "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.23.1.tgz",
+            "integrity": "sha512-Hu3T1/wfdbuQBZ//DBz2FwxAg+3/x9P1skS6sVldnq7yy3EZZpuOO7Tgu4OZbMlWHJG6IebWQnfniyRTOl9mVA==",
             "bin": {
                 "core-styles": "src/cli.js"
             },
@@ -2991,7 +2991,7 @@
                 "js-yaml": "^4.1.0",
                 "merge-lite": "^1.0.2",
                 "node-cmd": "^5.0.0",
-                "postcss": "^8.4.18",
+                "postcss": "^8.4.31",
                 "postcss-banner": "^4.0.1",
                 "postcss-cli": "^10.0.0",
                 "postcss-extend": "^1.0.5",
@@ -5889,9 +5889,9 @@
             "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.3",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-            "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
             "funding": [
                 {
                     "type": "individual",
@@ -9171,7 +9171,7 @@
             "integrity": "sha512-zplAc8IovPMe/JqV0B9nl6o6sElIX7VX1CP2FbV+lGZud3hcnDMr4clN0S8xdHthQoTNDN2K1Q+z0YEW5FWc8A==",
             "peer": true,
             "dependencies": {
-                "postcss": "^5.0.4"
+                "postcss": "^8.4.18"
             }
         },
         "node_modules/postcss-extend/node_modules/ansi-regex": {
@@ -9236,9 +9236,9 @@
             }
         },
         "node_modules/postcss-extend/node_modules/postcss": {
-            "version": "5.2.18",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-            "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+            "version": "8.4.31",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
             "peer": true,
             "dependencies": {
                 "chalk": "^1.1.3",
@@ -11467,9 +11467,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.7.tgz",
-            "integrity": "sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==",
+            "version": "3.2.8",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.8.tgz",
+            "integrity": "sha512-EtQU16PLIJpAZol2cTLttNP1mX6L0SyI0pgQB1VOoWeQnMSvtiwovV3D6NcjN8CZQWWyESD2v5NGnpz5RvgOZA==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.15.9",

--- a/react/package.json
+++ b/react/package.json
@@ -24,7 +24,7 @@
         "@babel/preset-typescript": "^7.21.0",
         "@changey/react-leaflet-markercluster": "^4.0.0-rc1",
         "@reduxjs/toolkit": "^1.8.4",
-        "@tacc/core-styles": "^2.22.6",
+        "@tacc/core-styles": "^2.23.1",
         "@testing-library/react": "^13.4.0",
         "@types/leaflet.markercluster": "^1.5.1",
         "axios": "^1.6.2",


### PR DESCRIPTION
## Overview: ##
Addressing postcss vulnerability issues by updating packages and changing dependencies of those packages.
Perviously there were 3 moderate vulnerabilities related to tacc-core-styles package.

## PR Status: ##

* [ ] Ready.
* [X] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-215](https://tacc-main.atlassian.net/browse/WG-215)

## Summary of Changes: ##

- Updated tacc-core-styles package to version 2.23.1
- Updated the package.lock file, specifically postcss and postcss-extend (which were causing the issues, as they were nested dependencies of tacc-core-styles), to have dependencies of newer postcss versions. Perviously postcss-extend was compatible with version 5 of postcss. I need to test the application to make sure using postcss ^8.4.18 with postcss-extend doesn't cause any side effects.

## Testing Steps: ##
1. 

## UI Photos:

## Notes: ##
TO-DO: Running 'npm ci' command works for updated package-lock file. However, running 'npm install' command will overwrite these changes bc postcss-extend's individual package.json file has postcss version ^5.0.4 as its dependency range, therefore npm will overwrite (and the vulnerabilities will return) postcss's package-lock contents (postcss-extend is a nested dependency of postcss and tacc-core-styles pacakges). Looking for alternate solution for long-term fix. 

Note: CEP is using tacc-core-styles: ^2.11.0 for their versioning. They're also using the postcss-extend-rule package instead of postcss-extend. Will look into this further as an option