### PR TITLE
task/WG-216: addressing css minifying warnings

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -18,6 +18,18 @@
     "eslintConfig": {
         "extends": "react-app"
     },
+    "browserslist": {
+        "production": [
+          ">0.2%",
+          "not dead",
+          "not op_mini all"
+        ],
+        "development": [
+          "last 1 chrome version",
+          "last 1 firefox version",
+          "last 1 safari version"
+        ]
+    },
     "dependencies": {
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-react": "^7.18.6",

--- a/react/postcss.config.cjs
+++ b/react/postcss.config.cjs
@@ -1,0 +1,21 @@
+/* eslint-disable */
+
+module.exports = {
+    plugins: [
+      require('postcss-preset-env')({
+        stage: false,
+        features: {
+          'custom-media-queries': true,
+          'media-query-ranges': true,
+          'custom-selectors': true,
+          'nesting-rules': true,
+        },
+      }),
+      require('postcss-replace')({
+        pattern: 'fonts/',
+        data: {
+          replaceAll: '../fonts/',
+        },
+      }),
+    ],
+  };

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -9,5 +9,17 @@ export default defineConfig(({ command, mode }) => { // eslint-disable-line
       port: 4200,
       host: 'localhost',
     },
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('node_modules')) {
+              return 'vendor';
+            }
+          },
+        },
+      },
+      chunkSizeWarningLimit: 700,
+    },
   };
 });


### PR DESCRIPTION
## Overview: ##
Addressed CSS minifying warnings by adding postcss config file that is based off of TUP's yaml file. Added some code to vite config to deal with build and chunk size issues. 
## PR Status: ##

* [x] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-216](https://tacc-main.atlassian.net/browse/WG-216)

## Summary of Changes: ##

- Created postcss.config.cjs file that allows vite to understand how to deal with css minifying warnings and nesting. 
- Updated vite.config.ts file to handle build and chunk size warnings during 'npm run build' command.
- Updated chunk size limit to 700.
- For optimization (regarding the chunk size warning) I created a conditional in vite.config.ts file that will separate all third-party node modules into a separate 'vendor' group. This will help with loading. 
- Added additional code (got this from CEP codebase) to the package.json file that specifies the browsers the application will support, with different targets for production and development environments. Supposed to help with optimization for babel and postcss during build.

## Testing Steps: ##
1. Run the 'npm run build' command
2. You should no longer see any css minifying warnings.
3. You should no longer see any chunk size limit warnings.
4. Compare with screenshot below

## UI Photos:
<img width="603" alt="Screenshot 2024-01-30 at 9 27 17 AM" src="https://github.com/TACC-Cloud/hazmapper/assets/50084480/1da68e06-ca1c-4dfb-981f-64a387ffe295">

## Notes: ##
