### PR TITLE
task/WG-261: mock v3 project designsafe

### DIFF
--- a/angular/src/app/fixtures/projectv3.fixture.ts
+++ b/angular/src/app/fixtures/projectv3.fixture.ts
@@ -1,0 +1,72 @@
+const projectFixturev3 = {
+  result: [
+    {
+      uuid: '4983294419299528210-242ac118-0001-012',
+      name: 'designsafe.project',
+      value: {
+        ef: '',
+        dois: [],
+        title: 'TEST: Hazmapper/TapisV3 project',
+        users: [
+          {
+            role: 'pi',
+            user: null,
+            username: 'nathanf',
+            authorship: null,
+          },
+          {
+            role: 'co_pi',
+            user: null,
+            username: 'tgrafft',
+            authorship: null,
+          },
+          {
+            role: 'co_pi',
+            user: null,
+            username: 'thbrown',
+            authorship: null,
+          },
+          {
+            role: 'team_member',
+            user: null,
+            username: 'sal',
+            authorship: null,
+          },
+          {
+            role: 'team_member',
+            user: null,
+            username: 'khan263s',
+            authorship: null,
+          },
+          {
+            role: 'team_member',
+            user: null,
+            username: 'wbomar',
+            authorship: null,
+          },
+          {
+            role: 'team_member',
+            user: null,
+            username: 'jgentle',
+            authorship: null,
+          },
+          {
+            role: 'team_member',
+            user: null,
+            username: 'smassie',
+            authorship: null,
+          },
+        ],
+        projectId: 'PRJ-2224',
+        description: '',
+        hazmapperMaps: [],
+      },
+      created: '2024-02-28T14:28:24.101-06:00',
+      lastUpdated: '2024-02-28T14:28:24.101-06:00',
+      associationIds: [],
+    },
+  ],
+  total: 1,
+};
+
+export { projectFixturev3 };

--- a/angular/src/app/services/agave-systems.service.ts
+++ b/angular/src/app/services/agave-systems.service.ts
@@ -6,7 +6,7 @@ import { BehaviorSubject, Observable, ReplaySubject, combineLatest } from 'rxjs'
 import { map } from 'rxjs/operators';
 import { HttpClient } from '@angular/common/http';
 import { EnvService } from '../services/env.service';
-import { DesignSafeProjectCollection, Project } from '../models/models';
+import { Project } from '../models/models';
 import { projectFixturev3 } from '../fixtures/projectv3.fixture';
 
 export interface AgaveProjectsData {
@@ -63,6 +63,26 @@ export class AgaveSystemsService {
     // See https://tacc-main.atlassian.net/browse/WG-261
     this._projects.next([]);
     this._loadingProjects.next(false);
+    /*
+    this.http.get<DesignSafeProjectCollection>(this.envService.designSafeUrl + `/projects/v2/`).subscribe(
+      (resp) => {
+        const projectSystems = resp.projects.map((project) => {
+          return {
+            id: 'project-' + project.uuid,
+            name: project.value.projectId,
+            description: project.value.title,
+          };
+        });
+        this._projects.next(projectSystems);
+        this._loadingProjects.next(false);
+      },
+      (error) => {
+        this._projects.next(null);
+        this._loadingProjectsFailedMessage.next(error.message || 'An error occured.');
+        this._loadingProjects.next(false);
+      }
+    );
+    */
     const useMockSuccess = true; // Change this to false to simulate an error
     if (useMockSuccess) {
       const mockResponse = projectFixturev3;
@@ -82,26 +102,6 @@ export class AgaveSystemsService {
       this._loadingProjects.next(false);
     }
   }
-
-  //   this.http.get<DesignSafeProjectCollection>(this.envService.designSafeUrl + `/projects/v2/`).subscribe(
-  //     (resp) => {
-  //       const projectSystems = resp.projects.map((project) => {
-  //         return {
-  //           id: 'project-' + project.uuid,
-  //           name: project.value.projectId,
-  //           description: project.value.title,
-  //         };
-  //       });
-  //       this._projects.next(projectSystems);
-  //       this._loadingProjects.next(false);
-  //     },
-  //     (error) => {
-  //       this._projects.next(null);
-  //       this._loadingProjectsFailedMessage.next(error.message || 'An error occured.');
-  //       this._loadingProjects.next(false);
-  //     }
-  //   );
-  // }
 
   getProjectMetadata(projects: Project[], dsProjects: SystemSummary[]): Project[] {
     if (dsProjects && dsProjects.length > 0) {

--- a/angular/src/app/services/agave-systems.service.ts
+++ b/angular/src/app/services/agave-systems.service.ts
@@ -6,7 +6,8 @@ import { BehaviorSubject, Observable, ReplaySubject, combineLatest } from 'rxjs'
 import { map } from 'rxjs/operators';
 import { HttpClient } from '@angular/common/http';
 import { EnvService } from '../services/env.service';
-import { Project } from '../models/models';
+import { DesignSafeProjectCollection, Project } from '../models/models';
+import { projectFixturev3 } from '../fixtures/projectv3.fixture';
 
 export interface AgaveProjectsData {
   projects: SystemSummary[];
@@ -62,27 +63,45 @@ export class AgaveSystemsService {
     // See https://tacc-main.atlassian.net/browse/WG-261
     this._projects.next([]);
     this._loadingProjects.next(false);
-    /*
-    this.http.get<DesignSafeProjectCollection>(this.envService.designSafeUrl + `/projects/v2/`).subscribe(
-      (resp) => {
-        const projectSystems = resp.projects.map((project) => {
-          return {
-            id: 'project-' + project.uuid,
-            name: project.value.projectId,
-            description: project.value.title,
-          };
-        });
-        this._projects.next(projectSystems);
-        this._loadingProjects.next(false);
-      },
-      (error) => {
-        this._projects.next(null);
-        this._loadingProjectsFailedMessage.next(error.message || 'An error occured.');
-        this._loadingProjects.next(false);
-      }
-    );
-    */
+    const useMockSuccess = true; // Change this to false to simulate an error
+    if (useMockSuccess) {
+      const mockResponse = projectFixturev3;
+      const projectSystems = mockResponse.result.map((project) => {
+        return {
+          id: 'project-' + project.uuid,
+          name: project.value.projectId,
+          description: project.value.title,
+        };
+      });
+      this._projects.next(projectSystems);
+      this._loadingProjects.next(false);
+    } else {
+      const errorMessage = 'An error occurred. Contact support';
+      this._projects.next(null);
+      this._loadingProjectsFailedMessage.next(errorMessage);
+      this._loadingProjects.next(false);
+    }
   }
+
+  //   this.http.get<DesignSafeProjectCollection>(this.envService.designSafeUrl + `/projects/v2/`).subscribe(
+  //     (resp) => {
+  //       const projectSystems = resp.projects.map((project) => {
+  //         return {
+  //           id: 'project-' + project.uuid,
+  //           name: project.value.projectId,
+  //           description: project.value.title,
+  //         };
+  //       });
+  //       this._projects.next(projectSystems);
+  //       this._loadingProjects.next(false);
+  //     },
+  //     (error) => {
+  //       this._projects.next(null);
+  //       this._loadingProjectsFailedMessage.next(error.message || 'An error occured.');
+  //       this._loadingProjects.next(false);
+  //     }
+  //   );
+  // }
 
   getProjectMetadata(projects: Project[], dsProjects: SystemSummary[]): Project[] {
     if (dsProjects && dsProjects.length > 0) {


### PR DESCRIPTION
## Overview: ##
Jake provided a example of the new DS v3 project response. Because there is no v3 designsafe portal, yet, we needed to mock a response so we could get a listing of projects (each is its own system) from a UI standpoint when creating a new map. 
## PR Status: ##

* [x] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-261](https://tacc-main.atlassian.net/browse/WG-261)

## Summary of Changes: ##

- Created a projectv3.fixture.ts file that represents a project (project system) response that will come from the /api/projects endpoint once the v3 DS portal is up and running. 
- Added code to use the mock fixture so that the project would show under 'My Projects' in the dropdown when creating a new map and selecting a system to save the map. 

## Testing Steps: ##
1. For the backend, run local on the feature/tapisv3 branch
2. Run with angular hazmapper
3. Click the Create a Map button so the modal appears
4. Under the file browser, click the dropdown menu and confirm that both My Data and the example mock v3 project system fixture is present (this will be under My Projects as the name TEST: Hazmapper/TapisV3 project)
5. Compare with screenshot below and make sure file listings are showing too

## UI Photos:
<img width="1241" alt="Screenshot 2024-03-04 at 2 47 46 PM" src="https://github.com/TACC-Cloud/hazmapper/assets/50084480/51ec870f-b492-4b8e-afa8-1f8336960852">

## Notes: ##
Once v3 DS portal is up and running we will make a request to DS projects endpoint directly and remove the mock fixture. 