### PR TITLE
Hotfix/fix feature request

### DIFF
--- a/react/src/hooks/features/useFeatures.ts
+++ b/react/src/hooks/features/useFeatures.ts
@@ -25,17 +25,6 @@ const useFeatures = ({
     key: ['features', { projectId, isPublic }],
     options,
   });
-
-  if (!projectId) {
-    return {
-      ...query,
-      status: 'error',
-      error: new Error('Unknown project'),
-      data: undefined,
-      isFetching: false,
-    } as UseQueryResult<FeatureCollection>;
-  }
-
   return query;
 };
 

--- a/react/src/hooks/projects/useProjects.ts
+++ b/react/src/hooks/projects/useProjects.ts
@@ -25,7 +25,7 @@ export const useProject = ({
   const endpoint = `/${projectRoute}/?uuid=${projectUUID}`;
   const query = useGet<Project>({
     endpoint,
-    key: ['projects'],
+    key: ['project'],
     options,
     transform: (data) => data[0], // result is a list with a single Project
   });

--- a/react/src/hooks/tileServers/useTileServers.ts
+++ b/react/src/hooks/tileServers/useTileServers.ts
@@ -22,15 +22,5 @@ export const useTileServers = ({
     options,
   });
 
-  if (!projectId) {
-    return {
-      ...query,
-      status: 'error',
-      error: new Error('Unknown project'),
-      data: undefined,
-      isLoading: false,
-    } as UseQueryResult<TileServerLayer[]>;
-  }
-
   return query;
 };

--- a/react/src/pages/MapProject/MapProject.tsx
+++ b/react/src/pages/MapProject/MapProject.tsx
@@ -34,6 +34,9 @@ const MapProject: React.FC<Props> = ({ isPublic = false }) => {
     options: { enabled: !!projectUUID },
   });
 
+  const canFetchProjectFeaturesOrLayers =
+    !isActiveProjectLoading && !activeProjectError && !!activeProject;
+
   const {
     data: featureCollection,
     isLoading: isFeaturesLoading,
@@ -42,8 +45,7 @@ const MapProject: React.FC<Props> = ({ isPublic = false }) => {
     projectId: activeProject?.id,
     isPublic,
     options: {
-      enabled:
-        !isActiveProjectLoading && !activeProjectError && !!activeProject,
+      enabled: canFetchProjectFeaturesOrLayers,
     },
   });
 
@@ -55,8 +57,7 @@ const MapProject: React.FC<Props> = ({ isPublic = false }) => {
     projectId: activeProject?.id,
     isPublic,
     options: {
-      enabled:
-        !isActiveProjectLoading && !activeProjectError && !!activeProject,
+      enabled: canFetchProjectFeaturesOrLayers,
     },
   });
 


### PR DESCRIPTION
## Overview: ##

Fix the issue where features/layers requests are sent for an `undefined` project after a project was created and we have navigated to that project.

The main issue was that `useProjects` and `useProject` where using the same key (for reac-query).

## PR Status: ##

* [X] Ready.

## Testing Steps: ##
1.  Create a new map project
2. Ensure that there are no failing requests for projects' features/tile-layers