### PR TITLE
task/WG-264: Hazmapper suffix fix

### DIFF
--- a/react/src/components/CreateMapModal/CreateMapModal.module.css
+++ b/react/src/components/CreateMapModal/CreateMapModal.module.css
@@ -30,12 +30,11 @@
 }
 
 .hazmapper-suffix {
+  font-weight: bold;
   position: absolute;
-  right: 0;
-  padding-right: 10px;
-  top: 46%;
+  right: 8px;
   transform: translateY(-50%);
-  white-space: nowrap;
+  padding-left: 8px;
 }
 
 /* Adding media queries for mobile devices */

--- a/react/src/components/CreateMapModal/CreateMapModal.module.css
+++ b/react/src/components/CreateMapModal/CreateMapModal.module.css
@@ -37,6 +37,14 @@
   padding-left: 8px;
 }
 
+.hazmapper-suffix--error {
+  top: auto;
+}
+
+.hazmapper-suffix--normal {
+  top: 50%;
+}
+
 /* Adding media queries for mobile devices */
 @media (max-width: 440px) {
   .input-custom-size {

--- a/react/src/components/CreateMapModal/CreateMapModal.module.css
+++ b/react/src/components/CreateMapModal/CreateMapModal.module.css
@@ -33,16 +33,8 @@
   font-weight: bold;
   position: absolute;
   right: 8px;
-  transform: translateY(-50%);
+  top: 30px;
   padding-left: 8px;
-}
-
-.hazmapper-suffix--error {
-  top: auto;
-}
-
-.hazmapper-suffix--normal {
-  top: 50%;
 }
 
 /* Adding media queries for mobile devices */

--- a/react/src/components/CreateMapModal/CreateMapModal.tsx
+++ b/react/src/components/CreateMapModal/CreateMapModal.tsx
@@ -135,23 +135,24 @@ const CreateMapModal = ({
                       required
                       className={`${styles['input-custom-size']}`}
                     />
-                  <span
-                    className={`${styles['hazmapper-suffix']} ${
-                      errors.system_file && touched.system_file
-                        ? styles['hazmapper-suffix--error']
-                        : styles['hazmapper-suffix--normal']
-                    }`}
-                  >
-                    .hazmapper
-                  </span>
-                </div>
-                <div className={`${styles['field-wrapper-alt']}`}>
-                  <FormikInput
-                    name="save-location"
-                    label="Save Location"
-                    value={`/${userData?.username}`}
-                    readOnly
-                    disabled
+                    <span
+                      className={`${styles['hazmapper-suffix']} ${
+                        errors.system_file && touched.system_file
+                          ? styles['hazmapper-suffix--error']
+                          : styles['hazmapper-suffix--normal']
+                      }`}
+                    >
+                      .hazmapper
+                    </span>
+                  </div>
+                  <div className={`${styles['field-wrapper-alt']}`}>
+                    <FormikInput
+                      name="save-location"
+                      label="Save Location"
+                      value={`/${userData?.username}`}
+                      readOnly
+                      disabled
+                    />
                   </div>
                   <FormikCheck
                     name="syncFolder"

--- a/react/src/components/CreateMapModal/CreateMapModal.tsx
+++ b/react/src/components/CreateMapModal/CreateMapModal.tsx
@@ -120,13 +120,11 @@ const CreateMapModal = ({
                     className={`${styles['input-custom-size']}`}
                   />
                   <span
-                    className={`${styles['hazmapper-suffix']}`}
-                    style={{
-                      top:
-                        errors.system_file && touched.system_file
-                          ? 'auto'
-                          : '50%',
-                    }}
+                    className={`${styles['hazmapper-suffix']} ${
+                      errors.system_file && touched.system_file
+                        ? styles['hazmapper-suffix--error']
+                        : styles['hazmapper-suffix--normal']
+                    }`}
                   >
                     .hazmapper
                   </span>

--- a/react/src/components/CreateMapModal/CreateMapModal.tsx
+++ b/react/src/components/CreateMapModal/CreateMapModal.tsx
@@ -99,7 +99,7 @@ const CreateMapModal = ({
           validationSchema={validationSchema}
           onSubmit={handleSubmit}
         >
-          {({ errors, touched, values, setFieldValue }) => {
+          {({ values, setFieldValue }) => {
             useEffect(() => {
               // Replace spaces with underscores for system_file mirroring
               const systemFileName = values.name.replace(/\s+/g, '_');
@@ -135,13 +135,7 @@ const CreateMapModal = ({
                       required
                       className={`${styles['input-custom-size']}`}
                     />
-                    <span
-                      className={`${styles['hazmapper-suffix']} ${
-                        errors.system_file && touched.system_file
-                          ? styles['hazmapper-suffix--error']
-                          : styles['hazmapper-suffix--normal']
-                      }`}
-                    >
+                    <span className={`${styles['hazmapper-suffix']}`}>
                       .hazmapper
                     </span>
                   </div>

--- a/react/src/components/CreateMapModal/CreateMapModal.tsx
+++ b/react/src/components/CreateMapModal/CreateMapModal.tsx
@@ -100,7 +100,7 @@ const CreateMapModal = ({
           validationSchema={validationSchema}
           onSubmit={handleSubmit}
         >
-          {() => (
+          {({ errors, touched }) => (
             <Form className="c-form">
               <FieldWrapperFormik name="map-form-info" label="">
                 <FormikInput
@@ -121,7 +121,15 @@ const CreateMapModal = ({
                     required
                     className={`${styles['input-custom-size']}`}
                   />
-                  <span className={`${styles['hazmapper-suffix']}`}>
+                  <span
+                    className={`${styles['hazmapper-suffix']}`}
+                    style={{
+                      top:
+                        errors.system_file && touched.system_file
+                          ? 'auto'
+                          : '50%',
+                    }}
+                  >
                     .hazmapper
                   </span>
                 </div>


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [x] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-264](https://tacc-main.atlassian.net/browse/WG-264)

## Summary of Changes: ##

- Before this PR, the .hazmapper extenion was being pushed out of the input box every time the "File name required" text was rendered from the Yup validation.
- Now the hazmapper extension will stay inside the input box when the validation text appears, making the UI look cleaner. 

## Testing Steps: ##
1. Run with local geoapi backend (master branch is fine)
2. Open the "Create Map" modal
3. Verify that the ".hazmapper" extension is present in the Custom File Name field
4. Start typing a file name in that field, then delete the text and click out/unfocus from the Custom File Name field so that the "File name is required" text pops up. 
5. When it does, verify that the ".hazmapper" extension text is still inside the input box 
6. Compare with the screenshots below

## UI Photos:
<img width="670" alt="Screenshot 2024-03-28 at 3 24 41 PM" src="https://github.com/TACC-Cloud/hazmapper/assets/50084480/c0b7cae7-7b18-4803-8402-0728e758582f">
<img width="670" alt="Screenshot 2024-03-28 at 3 25 20 PM" src="https://github.com/TACC-Cloud/hazmapper/assets/50084480/a0388289-aaaa-44f0-a1a9-3cb2b9c2b78c">

## Notes: ##
