### PR TITLE
task/WG-274: Update projects for next

### DIFF
--- a/angular/src/app/components/users-panel/users-panel.component.ts
+++ b/angular/src/app/components/users-panel/users-panel.component.ts
@@ -41,19 +41,22 @@ export class UsersPanelComponent implements OnInit {
 
   ngOnInit() {
     this.agaveSystemsService.list();
-
+    // Update this to point to v3 Data Depot URLs on DesignSafe Next. This is in the Manage Panel under Save tab. 
     combineLatest([this.projectsService.activeProject, this.agaveSystemsService.projects]).subscribe(([activeProject, dsProjects]) => {
       if (activeProject) {
+        console.log(activeProject)
         const portalUrl = this.envService.portalUrl + 'data/browser/';
         this.activeProject = this.agaveSystemsService.getProjectMetadata([activeProject], dsProjects)[0];
         if (activeProject.system_id) {
+          console.log(activeProject.system_id)
           if (activeProject.system_id.startsWith('project')) {
             this.dsHref = portalUrl + 'projects/' + activeProject.system_id.substr(8) + '/' + activeProject.system_path + '/';
             if (activeProject.ds_id) {
               this.projectHref = portalUrl + 'projects/' + activeProject.system_id.substr(8) + '/';
             }
           } else {
-            this.myDataHref = portalUrl + 'agave/' + activeProject.system_id;
+            // Change agave to tapis
+            this.myDataHref = portalUrl + 'tapis/' + activeProject.system_id;
             this.dsHref = this.myDataHref + activeProject.system_path + '/';
           }
         }

--- a/angular/src/app/components/users-panel/users-panel.component.ts
+++ b/angular/src/app/components/users-panel/users-panel.component.ts
@@ -41,7 +41,6 @@ export class UsersPanelComponent implements OnInit {
 
   ngOnInit() {
     this.agaveSystemsService.list();
-    // Update this to point to v3 Data Depot URLs on DesignSafe Next. This is in the Manage Panel under Save tab. 
     combineLatest([this.projectsService.activeProject, this.agaveSystemsService.projects]).subscribe(([activeProject, dsProjects]) => {
       if (activeProject) {
         const portalUrl = this.envService.portalUrl + 'data/browser/';

--- a/angular/src/app/components/users-panel/users-panel.component.ts
+++ b/angular/src/app/components/users-panel/users-panel.component.ts
@@ -44,18 +44,15 @@ export class UsersPanelComponent implements OnInit {
     // Update this to point to v3 Data Depot URLs on DesignSafe Next. This is in the Manage Panel under Save tab. 
     combineLatest([this.projectsService.activeProject, this.agaveSystemsService.projects]).subscribe(([activeProject, dsProjects]) => {
       if (activeProject) {
-        console.log(activeProject)
         const portalUrl = this.envService.portalUrl + 'data/browser/';
         this.activeProject = this.agaveSystemsService.getProjectMetadata([activeProject], dsProjects)[0];
         if (activeProject.system_id) {
-          console.log(activeProject.system_id)
           if (activeProject.system_id.startsWith('project')) {
-            this.dsHref = portalUrl + 'projects/' + activeProject.system_id.substr(8) + '/' + activeProject.system_path + '/';
+            this.dsHref = portalUrl + 'projects/' + activeProject.ds_id + '/' + activeProject.system_path + '/';
             if (activeProject.ds_id) {
-              this.projectHref = portalUrl + 'projects/' + activeProject.system_id.substr(8) + '/';
+              this.projectHref = portalUrl + 'projects/' + activeProject.ds_id + '/';
             }
           } else {
-            // Change agave to tapis
             this.myDataHref = portalUrl + 'tapis/' + activeProject.system_id;
             this.dsHref = this.myDataHref + activeProject.system_path + '/';
           }

--- a/angular/src/app/models/models.ts
+++ b/angular/src/app/models/models.ts
@@ -241,5 +241,5 @@ export interface DesignSafeProject {
 }
 
 export interface DesignSafeProjectCollection {
-  projects: DesignSafeProject[];
+  result: DesignSafeProject[];
 }

--- a/angular/src/app/services/agave-systems.service.ts
+++ b/angular/src/app/services/agave-systems.service.ts
@@ -7,7 +7,7 @@ import { map } from 'rxjs/operators';
 import { HttpClient } from '@angular/common/http';
 import { EnvService } from '../services/env.service';
 import { Project } from '../models/models';
-import { projectFixturev3 } from '../fixtures/projectv3.fixture';
+import { DesignSafeProjectCollection } from '../models/models';
 
 export interface AgaveProjectsData {
   projects: SystemSummary[];
@@ -59,12 +59,10 @@ export class AgaveSystemsService {
     this._loadingProjects.next(true);
     this._loadingProjectsFailedMessage.next(null);
 
-    // TODO_TAPISV3 mock a response from projects endpoint and use designsafe directly i.e. /api/projects
-    // See https://tacc-main.atlassian.net/browse/WG-261
     this._projects.next([]);
     this._loadingProjects.next(false);
-    /*
-    this.http.get<DesignSafeProjectCollection>(this.envService.designSafeUrl + `/projects/v2/`).subscribe(
+
+    this.http.get<DesignSafeProjectCollection>(this.envService.designSafeUrl + `/api/projects/v2/`).subscribe(
       (resp) => {
         const projectSystems = resp.projects.map((project) => {
           return {
@@ -82,25 +80,6 @@ export class AgaveSystemsService {
         this._loadingProjects.next(false);
       }
     );
-    */
-    const useMockSuccess = true; // Change this to false to simulate an error
-    if (useMockSuccess) {
-      const mockResponse = projectFixturev3;
-      const projectSystems = mockResponse.result.map((project) => {
-        return {
-          id: 'project-' + project.uuid,
-          name: project.value.projectId,
-          description: project.value.title,
-        };
-      });
-      this._projects.next(projectSystems);
-      this._loadingProjects.next(false);
-    } else {
-      const errorMessage = 'An error occurred. Contact support';
-      this._projects.next(null);
-      this._loadingProjectsFailedMessage.next(errorMessage);
-      this._loadingProjects.next(false);
-    }
   }
 
   getProjectMetadata(projects: Project[], dsProjects: SystemSummary[]): Project[] {

--- a/angular/src/app/services/agave-systems.service.ts
+++ b/angular/src/app/services/agave-systems.service.ts
@@ -64,7 +64,7 @@ export class AgaveSystemsService {
 
     this.http.get<DesignSafeProjectCollection>(this.envService.designSafeUrl + `/api/projects/v2/`).subscribe(
       (resp) => {
-        const projectSystems = resp.projects.map((project) => {
+        const projectSystems = resp.result.map((project) => {
           return {
             id: 'project-' + project.uuid,
             name: project.value.projectId,

--- a/angular/src/app/services/env.service.ts
+++ b/angular/src/app/services/env.service.ts
@@ -72,8 +72,7 @@ export class EnvService {
   }
 
   get designSafeUrl(): string {
-    // TODO_TAPISV3  just used for projects endpoint so shoud this be designsafe portal and not tapis tenant.
-    return 'https://designsafe.tapis.io/';
+    return 'https://designsafeci-next.tacc.utexas.edu';
   }
 
   get portalUrl(): string {

--- a/angular/src/app/services/env.service.ts
+++ b/angular/src/app/services/env.service.ts
@@ -118,7 +118,7 @@ export class EnvService {
     if (/^localhost/.test(hostname) || /^hazmapper.local/.test(hostname)) {
       this._env = EnvironmentType.Local;
       this._apiUrl = this.getApiUrl(environment.backend);
-      this._portalUrl = this.getPortalUrl(environment.backend);
+      this._portalUrl = this.getPortalUrl(EnvironmentType.Experimental);
       // TODO: Currently taggit is hosted on same port 4200
       // Have to change port on taggit or hazmapper (requires adding callbackUrl to that port)
       this._taggitUrl = 'http://localhost:4200/taggit';

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -12,7 +12,7 @@ export interface AppEnvironment {
 }
 
 export const environment: AppEnvironment = {
-  backend: EnvironmentType.Local,
+  backend: EnvironmentType.Experimental,
   jwt: devJWT,
   production: false,
 };

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -12,7 +12,7 @@ export interface AppEnvironment {
 }
 
 export const environment: AppEnvironment = {
-  backend: EnvironmentType.Experimental,
+  backend: EnvironmentType.Local,
   jwt: devJWT,
   production: false,
 };


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [x] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-274](https://tacc-main.atlassian.net/browse/WG-274)

## Summary of Changes: ##

- Using ds_id instead of system_id in the Users panel because Designsafe-Next uses PRJ in its URL rather than the system uuid like previously. (Related to the two links in the Manage, Save tab on user panel)
- Updated code to match structure of response data, as well as the URLs where the request are made on the new DS Next site
- DesignsafeURL and Portal URL now use DS Next.
- Projects request endpoint is now appropriately updated for new DS Next site. 

## Testing Steps: ##
1. 

## UI Photos:

## Notes: ##
Waiting for nginx conf to be merged for DS Next before merging this PR.