### PR TITLE
task/WG-276: Moving Create Map Button to ProjectListings

### DIFF
--- a/react/src/components/Projects/ProjectListing.tsx
+++ b/react/src/components/Projects/ProjectListing.tsx
@@ -1,13 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Project, DesignSafeProject } from '../../types';
 import {
   useDsProjects,
   useProjects,
   mergeDesignSafeProject,
 } from '../../hooks';
-import { LoadingSpinner } from '../../core-components';
+import { Button, LoadingSpinner } from '../../core-components';
+import CreateMapModal from '../CreateMapModal/CreateMapModal';
 
 export const ProjectListing: React.FC = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const toggleModal = () => {
+    setIsModalOpen(!isModalOpen);
+  };
+
   const { data, isLoading, isError } = useProjects();
   let projectsData: Array<Project> = [];
   let dsData: Array<DesignSafeProject> = [];
@@ -33,7 +40,10 @@ export const ProjectListing: React.FC = () => {
           <th>Map</th>
           <th>Project</th>
           <th>
-            <button>Create a New Map</button>
+            <CreateMapModal isOpen={isModalOpen} toggle={toggleModal} />
+            <Button onClick={toggleModal} size="small">
+              Create a New Map
+            </Button>
           </th>
         </tr>
       </thead>

--- a/react/src/pages/MainMenu/MainMenu.tsx
+++ b/react/src/pages/MainMenu/MainMenu.tsx
@@ -4,11 +4,9 @@ import {
   InlineMessage,
   SectionHeader,
   Icon,
-  Button,
 } from '../../core-components';
 import useAuthenticatedUser from '../../hooks/user/useAuthenticatedUser';
 import { SystemSelect } from '../../components/Systems';
-import CreateMapModal from '../../components/CreateMapModal/CreateMapModal';
 import { ProjectListing } from '../../components/Projects/ProjectListing';
 
 function MainMenu() {
@@ -17,11 +15,6 @@ function MainMenu() {
     isLoading: isUserLoading,
     error: userError,
   } = useAuthenticatedUser();
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const toggleModal = () => {
-    setIsModalOpen(!isModalOpen);
-  };
 
   const [selectedSystem, setSelectedSystem] = useState('');
 
@@ -48,14 +41,10 @@ function MainMenu() {
     <>
       <SectionHeader isNestedHeader>Main Menu</SectionHeader>
       <div>
-        <Button type="primary" size="small" onClick={toggleModal}>
-          Create Map
-        </Button>
+        <InlineMessage type="info">
+          Welcome, {userData?.username || 'User'} <Icon name="user"></Icon>
+        </InlineMessage>
       </div>
-      <InlineMessage type="info">
-        Welcome, {userData?.username || 'User'} <Icon name="user"></Icon>
-      </InlineMessage>
-      <CreateMapModal isOpen={isModalOpen} toggle={toggleModal} />
       <ProjectListing />
       {selectedSystem && <div>Current system selected: {selectedSystem}</div>}
       <SystemSelect onSystemSelect={handleSelectChange}></SystemSelect>


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-276](https://tacc-main.atlassian.net/browse/WG-276)

## Summary of Changes: ##

- Moved the Create Map button and comp/modal callback from the MainMenu to the ProjectListing comp.

## Testing Steps: ##
1. Run React hazmapper client (production is fine to run as the backend) and go to localhost:4200. 
2. Click the "Create a New Map" button (now in the ProjectListings comp) and make sure the modal comes up as expected.

## UI Photos:
![Screenshot 2024-04-24 at 9 50 09 AM](https://github.com/TACC-Cloud/hazmapper/assets/50084480/a6e7c969-6d0c-4a4c-8d1f-844019fd5b15)


## Notes: ##
