### PR TITLE
task/WG-275: update routes for backend geoapi to use hazmapper.tacc.utexas.edu

### DIFF
--- a/angular/src/app/services/env.service.ts
+++ b/angular/src/app/services/env.service.ts
@@ -17,13 +17,13 @@ export class EnvService {
     if (backend === EnvironmentType.Local) {
       return 'http://localhost:8888';
     } else if (backend === EnvironmentType.Staging) {
-      return 'https://staging.geoapi-services.tacc.utexas.edu';
+      return 'https://hazmapper.tacc.utexas.edu/geoapi-staging';
     } else if (backend === EnvironmentType.Production) {
-      return 'https://prod.geoapi-services.tacc.utexas.edu';
+      return 'https://hazmapper.tacc.utexas.edu/geoapi';
     } else if (backend === EnvironmentType.Dev) {
-      return 'https://dev.geoapi-services.tacc.utexas.edu';
+      return 'https://hazmapper.tacc.utexas.edu/geoapi-dev';
     } else if (backend === EnvironmentType.Experimental) {
-      return 'https://experimental.geoapi-services.tacc.utexas.edu';
+      return 'https://hazmapper.tacc.utexas.edu/geoapi-experimental';
     } else {
       throw new Error('Unsupported Type');
     }


### PR DESCRIPTION
## Overview: ##

We've updated hazmapper.tacc.utexas.edu to route all backend requests to the geoapi-services VMs.  This updates the client to use the same routes.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-257](https://tacc-main.atlassian.net/browse/WG-275)

## Testing Steps: ##
1. We tested with local client using experimental backend