### PR TITLE
task/WG-287 - File listing fix hazmapper

### DIFF
--- a/angular/src/app/components/file-browser/file-browser.component.ts
+++ b/angular/src/app/components/file-browser/file-browser.component.ts
@@ -120,17 +120,19 @@ export class FileBrowserComponent implements OnInit {
 
           this.currentPath.next(this.currentDirectory.path);
 
-          // Add '..' entry for users to move to parent path
-          const backPath = {
-            name: '..',
-            format: 'folder',
-            type: 'dir',
-            mimeType: 'test/directory',
-            size: 8192,
-            path: this.tapisFilesService.getParentPath(this.currentDirectory.path),
-            system: this.currentDirectory.system,
-          };
-          files.unshift(backPath);
+          // If this is the first load, add the '..' entry for users to move to parent path
+          if (this.offset === 0) {
+            const backPath = {
+              name: '..',
+              format: 'folder',
+              type: 'dir',
+              mimeType: 'test/directory',
+              size: 8192,
+              path: this.tapisFilesService.getParentPath(this.currentDirectory.path),
+              system: this.currentDirectory.system,
+            };
+            this.filesList.unshift(backPath);
+          }
 
           this.inProgress = false;
           this.filesList = this.filesList.concat(files);


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-287](https://tacc-main.atlassian.net/browse/WG-287)

## Summary of Changes: ##

- Added a condition where the `..` backPath folder is only added in the first load when the offset is 0 
- Made a change so that the `..` backPath is added to the `filesList` array instead of the `files` array from the api response. Originally, the change in length from the added backPath entry was causing the offset to be 1 larger than expected which broke the infinite scroll functionality

## Testing Steps: ##
1. Start the Angular application and open the file browser modal by selecting `Import from DesignSafe` under Assets
2. Select a system with lots of files/folders (`Published Data` has hundreds)
3. Scroll the listing and ensure that the listing works smoothly and there are no duplicate `..` folders. Can also monitor the Network tab to ensure new data with updated offset is being fetched

## UI Photos:

No UI changes

## Notes: ##
