### PR TITLE
task/WG-268: add authentification to backend

### DIFF
--- a/angular/src/app/app-routing.module.ts
+++ b/angular/src/app/app-routing.module.ts
@@ -46,7 +46,7 @@ const routes: Routes = [
       },
     ],
   },
-  { path: 'callback', component: CallbackComponent },
+  { path: 'handle-login', component: CallbackComponent },
   { path: 'streetview/callback', component: StreetviewCallbackComponent },
   { path: '404', component: NotFoundComponent },
   { path: '**', redirectTo: '', pathMatch: 'full' },

--- a/angular/src/app/app.interceptors.ts
+++ b/angular/src/app/app.interceptors.ts
@@ -23,12 +23,12 @@ export class JwtInterceptor implements HttpInterceptor {
       request.url.includes(this.envService.apiUrl) ||
       request.url.includes(this.envService.designSafeUrl);
     if (isTargetUrl) {
-      if(this.authSvc.isLoggedInButTokenExpired()){
+      if (this.authSvc.isLoggedInButTokenExpired()) {
         // check for an expired user token and get user to relogin if expired
         this.router.navigateByUrl(LOGIN + '?to=' + encodeURIComponent(this.router.url));
       }
 
-      if(this.authSvc.isLoggedIn()) {
+      if (this.authSvc.isLoggedIn()) {
         // add tapis token to Geoapi or Tapis requests
         request = request.clone({
           setHeaders: {

--- a/angular/src/app/app.module.ts
+++ b/angular/src/app/app.module.ts
@@ -29,7 +29,7 @@ import { AuthService } from './services/authentication.service';
 import { ModalService } from './services/modal.service';
 import { EnvService } from './services/env.service';
 import { CallbackComponent } from './components/callback/callback.component';
-import { AuthInterceptor, JwtInterceptor } from './app.interceptors';
+import { JwtInterceptor } from './app.interceptors';
 import { ModalCreateProjectComponent } from './components/modal-create-project/modal-create-project.component';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { ModalFileBrowserComponent } from './components/modal-file-browser/modal-file-browser.component';
@@ -153,11 +153,6 @@ import { QuestionnaireDetailComponent } from './components/questionnaire-detail/
       provide: HTTP_INTERCEPTORS,
       useClass: JwtInterceptor,
       multi: true,
-    },
-    {
-      provide: HTTP_INTERCEPTORS,
-      multi: true,
-      useClass: AuthInterceptor,
     },
     {
       provide: CDK_DRAG_CONFIG,

--- a/angular/src/app/components/callback/callback.component.ts
+++ b/angular/src/app/components/callback/callback.component.ts
@@ -11,8 +11,6 @@ export class CallbackComponent implements OnInit {
   constructor(private route: ActivatedRoute, private auth: AuthService) {}
 
   ngOnInit() {
-    const frag = this.route.snapshot.fragment;
-    const params = new URLSearchParams(frag);
     const token = this.route.snapshot.queryParams.access_token;
     const expires_in = this.route.snapshot.queryParams.expires_in;
     this.auth.setToken(token, expires_in);

--- a/angular/src/app/models/models.ts
+++ b/angular/src/app/models/models.ts
@@ -93,19 +93,26 @@ export class AuthToken {
     this.expires = new Date(expires);
   }
 
+  /** Creates an AuthToken instance from a token and an expiration time in seconds. */
   static fromExpiresIn(token: string, expires_in: number) {
     const expires = new Date(new Date().getTime() + expires_in * 1000);
     return new AuthToken(token, expires);
   }
 
+
   /**
-   * Checks if the token is expired or not
+   * Checks if the token is expired or not.
+   * A 5 minutebuffer is used to consider a token as expired slightly before its actual expiration time.
+   * @returns {boolean} True if the token is expired, false otherwise.
    */
   public isExpired(): boolean {
+    const buffer = 300000; // 5 minutes in milliseconds
     if (this.expires) {
-      return new Date().getTime() > this.expires.getTime();
+      // Subtract buffer from the expiration time and compare with the current time
+      return (new Date().getTime() > (this.expires.getTime() - buffer));
     } else {
-      return false;
+      // If expires is not set, consider the token as not expired
+      return false; // TODO_V3 this affects the streetview token; should be confirmed or refactored.
     }
   }
 }

--- a/angular/src/app/models/models.ts
+++ b/angular/src/app/models/models.ts
@@ -101,8 +101,8 @@ export class AuthToken {
 
   /**
    * Checks if the token is expired or not.
-   * A 5 minutebuffer is used to consider a token as expired slightly before its actual expiration time.
-   * @returns {boolean} True if the token is expired, false otherwise.
+   * A 5 minute buffer is used to consider a token as expired slightly before its actual expiration time.
+   * @returns True if the token is expired, false otherwise.
    */
   public isExpired(): boolean {
     const buffer = 300000; // 5 minutes in milliseconds

--- a/angular/src/app/models/models.ts
+++ b/angular/src/app/models/models.ts
@@ -99,7 +99,6 @@ export class AuthToken {
     return new AuthToken(token, expires);
   }
 
-
   /**
    * Checks if the token is expired or not.
    * A 5 minutebuffer is used to consider a token as expired slightly before its actual expiration time.
@@ -109,7 +108,7 @@ export class AuthToken {
     const buffer = 300000; // 5 minutes in milliseconds
     if (this.expires) {
       // Subtract buffer from the expiration time and compare with the current time
-      return (new Date().getTime() > (this.expires.getTime() - buffer));
+      return new Date().getTime() > this.expires.getTime() - buffer;
     } else {
       // If expires is not set, consider the token as not expired
       return false; // TODO_V3 this affects the streetview token; should be confirmed or refactored.

--- a/angular/src/app/services/authentication.service.ts
+++ b/angular/src/app/services/authentication.service.ts
@@ -31,7 +31,7 @@ export class AuthService {
   }
 
   public login(requestedUrl: string) {
-    this.logout()
+    this.logout();
     localStorage.setItem(this.getRedirectKeyword(), requestedUrl);
     this.redirectToAuthenticator(requestedUrl);
   }
@@ -54,18 +54,18 @@ export class AuthService {
     return false;
   }
 
-    /**
+  /**
    * Checks to see if there is a logged in user but token is expired;
    */
-    public isLoggedInButTokenExpired(): boolean {
-      const tokenStr = localStorage.getItem(this.getTokenKeyword());
-      if (tokenStr) {
-        const token = JSON.parse(tokenStr);
-        this.userToken = new AuthToken(token.token, new Date(token.expires));
-        return this.userToken && this.userToken.isExpired();
-      }
-      return false;
+  public isLoggedInButTokenExpired(): boolean {
+    const tokenStr = localStorage.getItem(this.getTokenKeyword());
+    if (tokenStr) {
+      const token = JSON.parse(tokenStr);
+      this.userToken = new AuthToken(token.token, new Date(token.expires));
+      return this.userToken && this.userToken.isExpired();
     }
+    return false;
+  }
 
   public logout(): void {
     this.userToken = null;

--- a/angular/src/app/services/authentication.service.ts
+++ b/angular/src/app/services/authentication.service.ts
@@ -23,7 +23,7 @@ export class AuthService {
   constructor(private http: HttpClient, private envService: EnvService, private router: Router) {}
 
   public getTokenKeyword() {
-    return `${this.envService.env}HazmapperToken`;
+    return `${this.envService.env}HazmapperV3Token`;
   }
 
   public getRedirectKeyword() {

--- a/angular/src/app/services/notifications.service.ts
+++ b/angular/src/app/services/notifications.service.ts
@@ -29,7 +29,6 @@ export class NotificationsService {
   }
 
   getRecent(): void {
-    this.authService.checkLoggedIn();
     const baseUrl = this.envService.apiUrl + '/notifications/';
     const now = new Date();
     const then = new Date(now.getTime() - this.TIMEOUT);
@@ -75,7 +74,6 @@ export class NotificationsService {
   }
 
   getRecentProgress(): void {
-    this.authService.checkLoggedIn();
     const baseUrl = this.envService.apiUrl + '/notifications/progress';
     this.http.get<Array<IProgressNotification>>(baseUrl).subscribe((notes) => {
       this._progressNotifications.next(notes);


### PR DESCRIPTION
## Overview: ##

Use geoapis new auth endpoints instead of authing with tapis.

Note: updating the key were we store this in local storage so not accidentally get a v3 token

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-268](https://tacc-main.atlassian.net/browse/WG-268)

## Summary of Changes: ##

## Testing Steps: ##
1. To be tested with https://github.com/TACC-Cloud/geoapi/pull/206
2. Ensure log-in works.   (`/login` or `/logout`
3. You could logout and then go to a URL of a map project and ensure after login you end up at that project).
4. You could change the "is-expired" buffer (in angular/src/app/models/models.ts) from 5 minutes to 3hrs and 55 minutes ( 14100000 ms).  So then the token which lasts 4 hours is updated after just 5 minutes of uses and you can see the login happening again.  
5. On server side, you could also change: BUFFER_TIME_WHEN_CHECKING_IF_ACCESS_TOKEN_WAS_RECENTLY_REFRESHED and BUFFER_TIME_FOR_EXPIRING_TOKENS  in jwt_utils.py



