### PR TITLE
task/WG-295: improve error message when duplicate syncing project

### DIFF
--- a/angular/src/app/components/modal-create-project/modal-create-project.component.ts
+++ b/angular/src/app/components/modal-create-project/modal-create-project.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, AfterContentChecked } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { BsModalRef } from 'ngx-foundation';
 import { FormGroup, FormControl } from '@angular/forms';
 import { ProjectsService } from '../../services/projects.service';
@@ -87,7 +88,7 @@ export class ModalCreateProjectComponent implements OnInit, AfterContentChecked 
       (project) => {
         this.close(project);
       },
-      (err) => {
+      (err: HttpErrorResponse) => {
         if (err.status === 409) {
           this.errorMessage = 'That folder is already syncing with a different map!';
         } else {

--- a/angular/src/app/components/modal-create-project/modal-create-project.component.ts
+++ b/angular/src/app/components/modal-create-project/modal-create-project.component.ts
@@ -88,8 +88,12 @@ export class ModalCreateProjectComponent implements OnInit, AfterContentChecked 
         this.close(project);
       },
       (err) => {
-        this.errorMessage = err.error && err.error.message ? err.error.message : 'That folder is already syncing with a different map!';
-
+        if (err.status === 409) {
+          this.errorMessage = 'That folder is already syncing with a different map!';
+        } else {
+          this.errorMessage =
+            err.error && err.error.message ? err.error.message : 'An error occurred while creating the project. Please contact support.';
+        }
         this.submitting = false;
       }
     );

--- a/angular/src/app/services/projects.service.ts
+++ b/angular/src/app/services/projects.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { BehaviorSubject, Observable, ReplaySubject, combineLatest } from 'rxjs';
 import { Project, ProjectRequest, ProjectUpdateRequest } from '../models/models';
 import { IpanelsDisplay, defaultPanelsDisplay } from '../models/ui';
@@ -112,15 +112,10 @@ export class ProjectsService {
 
   create(data: ProjectRequest): Observable<Project> {
     return this.http.post<Project>(this.envService.apiUrl + `/projects/`, data).pipe(
-      tap(
-        (proj) => {
-          // Spread operator, just pushes the new project into the array
-          this._projects.next([...this._projects.value, proj]);
-        },
-        (error) => {
-          console.log(error);
-        }
-      )
+      tap((proj) => {
+        // Spread operator, just pushes the new project into the array
+        this._projects.next([...this._projects.value, proj]);
+      })
     );
   }
 

--- a/angular/src/app/services/projects.service.ts
+++ b/angular/src/app/services/projects.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable, ReplaySubject, combineLatest } from 'rxjs';
 import { Project, ProjectRequest, ProjectUpdateRequest } from '../models/models';
 import { IpanelsDisplay, defaultPanelsDisplay } from '../models/ui';


### PR DESCRIPTION
## Overview: ##

This PR improves the error message when trying to create a duplicate syncing project.

This matches the error message handling we already have in the react client.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-XYZ](https://tacc-main.atlassian.net/browse/WG-295)
