### PR TITLE
task/wg-76-project-listing-query

### DIFF
--- a/react/src/components/Projects/ProjectListing.tsx
+++ b/react/src/components/Projects/ProjectListing.tsx
@@ -1,11 +1,7 @@
 import React, { useState } from 'react';
 import { Project, DesignSafeProject } from '../../types';
-import {
-  useDsProjects,
-  useProjects,
-  mergeDesignSafeProject,
-} from '../../hooks';
-import { Button, LoadingSpinner } from '../../core-components';
+import { useDsProjects, mergeDesignSafeProject } from '../../hooks';
+import { Button, LoadingSpinner, Icon } from '../../core-components';
 import CreateMapModal from '../CreateMapModal/CreateMapModal';
 import { useNavigate } from 'react-router-dom';
 
@@ -21,15 +17,8 @@ export const ProjectListing: React.FC = () => {
     setIsModalOpen(!isModalOpen);
   };
 
-  const { data, isLoading, isError } = useProjects();
-  let projectsData: Array<Project> = [];
-  let dsData: Array<DesignSafeProject> = [];
-  const resp = useDsProjects();
-  dsData = resp?.data?.projects ?? [];
-  projectsData = data ?? [];
-
-  const combinedProj = mergeDesignSafeProject(projectsData, dsData);
-  projectsData = combinedProj;
+  const projects = useDsProjects();
+  const { data, isLoading, isError } = mergeDesignSafeProject(projects);
 
   if (isLoading) {
     return <LoadingSpinner />;
@@ -40,30 +29,43 @@ export const ProjectListing: React.FC = () => {
   }
 
   return (
-    <table>
-      <thead>
-        <tr>
-          <th>Map</th>
-          <th>Project</th>
-          <th>
-            <CreateMapModal isOpen={isModalOpen} toggle={toggleModal} />
-            <Button onClick={toggleModal} size="small">
-              Create a New Map
-            </Button>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        {projectsData?.map((proj) => (
-          <tr key={proj.id} onClick={() => navigateToProject(proj.uuid)}>
-            <td>{proj.name}</td>
-            <td>
-              {proj.ds_project_id} {proj.ds_project_title}
-            </td>
-            <td></td>
+    <>
+      <table>
+        <thead>
+          <tr>
+            <th>Map</th>
+            <th>Project</th>
+            <th>
+              <CreateMapModal isOpen={isModalOpen} toggle={toggleModal} />
+              <Button
+                onClick={toggleModal}
+                size="small"
+              >
+                Create a New Map
+              </Button>
+            </th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {data?.map((proj) => (
+            <tr key={proj.id} onClick={() => navigateToProject(proj.uuid)}>
+              <td>{proj.name}</td>
+              <td>
+                {proj.ds_project?.value.projectId}{' '}
+                {proj.ds_project?.value.title}
+              </td>
+              <td>
+                <Button>
+                  <Icon name="edit-document"></Icon>
+                </Button>
+                <Button>
+                  <Icon name="trash"></Icon>
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
   );
 };

--- a/react/src/types/projects.ts
+++ b/react/src/types/projects.ts
@@ -20,7 +20,7 @@ export interface DesignSafeProject {
   value: any;
 }
 export interface DesignSafeProjectCollection {
-  projects?: DesignSafeProject[];
+  result?: DesignSafeProject[];
 }
 
 export class Project implements Project {}


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-76](https://tacc-main.atlassian.net/browse/WG-76)

## Summary of Changes: ##
Updates project type and hook so that the merged response from DesignSafe and Hazmapper load before loading the project listing

## Testing Steps: ##
1. Go to [http://localhost:4200/](http://localhost:4200/) and make sure that the Project immediately loads with table and map name. There previously was a delay as the component got the DesignSafe response.
2. Change  `if (isError)` or ` if {isLoading}` to `if (!isError) ` or `if (isLoading)` to check the display of those states.
3. Review code to make sure the project type and hooks are efficient.

## UI Photos:
<img width="892" alt="Screenshot 2024-09-30 at 12 32 41 PM" src="https://github.com/user-attachments/assets/776043f5-2fd0-40a8-a914-dd8a00478bb9">

## Notes: ##
TODO:
Edit and Trash buttons just open the map at this point. A delete and edit request have not been added yet.