### PR TITLE
hotfix:  use pprd.designsafe-ci.org

### DIFF
--- a/angular/src/app/services/env.service.ts
+++ b/angular/src/app/services/env.service.ts
@@ -38,8 +38,8 @@ export class EnvService {
       return 'https://www.designsafe-ci.org';
     } else if (backend === DesignSafeEnvironmentType.Next) {
       return 'https://designsafeci-next.tacc.utexas.edu';
-    } else if (backend === DesignSafeEnvironmentType.Dev) {
-      return 'https://designsafeci-dev.tacc.utexas.edu';
+    } else if (backend === DesignSafeEnvironmentType.PPRD) {
+      return 'https://pprd.designsafe-ci.org';
     } else {
       throw new Error('Unsupported DS environment');
     }
@@ -146,7 +146,7 @@ export class EnvService {
       this._env = EnvironmentType.Staging;
       this._apiUrl = this.getApiUrl(this.env);
       this._taggitUrl = origin + '/taggit-staging';
-      this._designSafePortalUrl = this.getDesignSafePortalUrl(DesignSafeEnvironmentType.Dev);
+      this._designSafePortalUrl = this.getDesignSafePortalUrl(DesignSafeEnvironmentType.PPRD);
       this._clientId = 'hazmapper.staging';
       this._baseHref = '/staging/';
       this._streetviewEnv.secrets = {
@@ -164,7 +164,7 @@ export class EnvService {
       this._env = EnvironmentType.Dev;
       this._apiUrl = this.getApiUrl(this.env);
       this._taggitUrl = origin + '/taggit-dev';
-      this._designSafePortalUrl = this.getDesignSafePortalUrl(DesignSafeEnvironmentType.Dev);
+      this._designSafePortalUrl = this.getDesignSafePortalUrl(DesignSafeEnvironmentType.PPRD);
       this._clientId = 'hazmapper.dev';
       this._baseHref = '/dev/';
       this._streetviewEnv.secrets = {

--- a/angular/src/environments/environmentType.ts
+++ b/angular/src/environments/environmentType.ts
@@ -8,7 +8,7 @@ export enum EnvironmentType {
 
 export enum DesignSafeEnvironmentType {
   Production = 'production' /* https://www.designsafe-ci.org/ */,
-  Dev = 'dev' /* https://designsafeci-dev.tacc.utexas.edu/ */,
+  PPRD = 'pprd' /* https://pprd.designsafe-ci.org */,
   Next = 'experimental' /* https://designsafeci-next.tacc.utexas.edu/ */,
   Local = 'local' /* not supported but would be designsafe.dev */,
 }

--- a/react/src/hooks/environment/getLocalAppConfiguration.ts
+++ b/react/src/hooks/environment/getLocalAppConfiguration.ts
@@ -20,7 +20,7 @@ export const getLocalAppConfiguration = (
     basePath: basePath,
     geoapiUrl: getGeoapiUrl(localDevelopmentConfiguration.geoapiBackend),
     designsafePortalUrl: getDesignsafePortalUrl(
-      DesignSafePortalEnvironment.Dev
+      DesignSafePortalEnvironment.PPRD
     ),
     tapisUrl: 'https://designsafe.tapis.io',
     mapillary: mapillaryConfig,

--- a/react/src/hooks/environment/useAppConfiguration.ts
+++ b/react/src/hooks/environment/useAppConfiguration.ts
@@ -48,7 +48,7 @@ export const useAppConfiguration = (): AppConfiguration => {
         basePath: basePath,
         geoapiUrl: getGeoapiUrl(GeoapiBackendEnvironment.Staging),
         designsafePortalUrl: getDesignsafePortalUrl(
-          DesignSafePortalEnvironment.Dev
+          DesignSafePortalEnvironment.PPRD
         ),
         tapisUrl: 'https://designsafe.tapis.io',
         mapillary: mapillaryConfig,
@@ -69,7 +69,7 @@ export const useAppConfiguration = (): AppConfiguration => {
         basePath: basePath,
         geoapiUrl: getGeoapiUrl(GeoapiBackendEnvironment.Dev),
         designsafePortalUrl: getDesignsafePortalUrl(
-          DesignSafePortalEnvironment.Dev
+          DesignSafePortalEnvironment.PPRD
         ),
         tapisUrl: 'https://designsafe.tapis.io',
         mapillary: mapillaryConfig,

--- a/react/src/hooks/environment/utils.ts
+++ b/react/src/hooks/environment/utils.ts
@@ -35,8 +35,8 @@ export function getDesignsafePortalUrl(
     return 'https://www.designsafe-ci.org';
   } else if (backend === DesignSafePortalEnvironment.Next) {
     return 'https://designsafeci-next.tacc.utexas.edu';
-  } else if (backend === DesignSafePortalEnvironment.Dev) {
-    return 'https://designsafeci-dev.tacc.utexas.edu';
+  } else if (backend === DesignSafePortalEnvironment.PPRD) {
+    return 'https://pprd.designsafe-ci.org';
   } else {
     throw new Error('Unsupported DS environment');
   }

--- a/react/src/types/environment.ts
+++ b/react/src/types/environment.ts
@@ -14,7 +14,7 @@ export enum GeoapiBackendEnvironment {
  */
 export enum DesignSafePortalEnvironment {
   Production = 'production' /* https://www.designsafe-ci.org/ */,
-  Dev = 'dev' /* https://designsafeci-dev.tacc.utexas.edu/ This dev is comparable to Geoapi's staging */,
+  PPRD = 'PPRD' /* https://pprd.designsafe-ci.org;  This is comparable to Geoapi's staging. */,
   Next = 'experimental' /* https://designsafeci-next.tacc.utexas.edu/ */,
   Local = 'local' /* not supported but would be designsafe.dev */,
 }


### PR DESCRIPTION
## Overview: ##

Switch to use https://pprd.designsafe-ci.org as https://designsafeci-dev.tacc.utexas.edu is retired.

 from [slack](https://tacc-team.slack.com/archives/C07JX8SDKC3/p1733763957055059?thread_ts=1733762362.801559&cid=C07JX8SDKC3) 

## PR Status: ##

* [X] Ready.