### PR TITLE
hotfix:  show duplicate file paths in feature tree

### DIFF
--- a/react/src/__fixtures__/featuresFixture.ts
+++ b/react/src/__fixtures__/featuresFixture.ts
@@ -94,3 +94,97 @@ export const featureCollectionWithNestedPaths: FeatureCollection = {
     },
   ],
 };
+
+export const featureCollectionWithDuplicateImages: FeatureCollection = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      id: 1,
+      project_id: 80,
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [-80.780375, 32.6185055555556],
+      } as Point,
+      properties: {},
+      styles: {},
+      assets: [
+        {
+          id: 2036562,
+          path: '80/f7c2afa2-f184-40a7-80be-0874a7db755e.jpeg',
+          uuid: 'f7c2afa2-f184-40a7-80be-0874a7db755e',
+          asset_type: 'image' as AssetType,
+          original_path: '/image1.JPG',
+          original_name: null,
+          display_path: '/image1.JPG',
+        },
+      ],
+    },
+    {
+      id: 2,
+      project_id: 80,
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [-80.780375, 32.6185055555556],
+      } as Point,
+      properties: {},
+      styles: {},
+      assets: [
+        {
+          id: 2036568,
+          path: '80/f7c2afa2-f184-40a7-80be-0874a7db755e.jpeg',
+          uuid: 'f7c2afa2-f184-40a7-80be-0874a7db755e',
+          asset_type: 'image' as AssetType,
+          original_path: '/image1.JPG',
+          original_name: null,
+          display_path: '/image1.JPG',
+        },
+      ],
+    },
+    {
+      id: 3,
+      project_id: 80,
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [-80.780375, 32.6185055555556],
+      } as Point,
+      properties: {},
+      styles: {},
+      assets: [
+        {
+          id: 2036568,
+          path: '80/f7c2afa2-f184-40a7-80be-0874a7db755e.jpeg',
+          uuid: 'f7c2afa2-f184-40a7-80be-0874a7db755e',
+          asset_type: 'image' as AssetType,
+          original_path: '/folder1/image1.JPG',
+          original_name: null,
+          display_path: '/folder1/image1.JPG',
+        },
+      ],
+    },
+    {
+      id: 4,
+      project_id: 80,
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [-80.780375, 32.6185055555556],
+      } as Point,
+      properties: {},
+      styles: {},
+      assets: [
+        {
+          id: 2036568,
+          path: '80/f7c2afa2-f184-40a7-80be-0874a7db755e.jpeg',
+          uuid: 'f7c2afa2-f184-40a7-80be-0874a7db755e',
+          asset_type: 'image' as AssetType,
+          original_path: '/folder1/image1.JPG',
+          original_name: null,
+          display_path: '/folder1/image1.JPG',
+        },
+      ],
+    },
+  ],
+};

--- a/react/src/utils/featureTreeUtils.test.ts
+++ b/react/src/utils/featureTreeUtils.test.ts
@@ -1,5 +1,8 @@
 import { featureCollectionToFileNodeArray } from './featureTreeUtils';
-import { featureCollectionWithNestedPaths } from '@hazmapper/__fixtures__/featuresFixture';
+import {
+  featureCollectionWithNestedPaths,
+  featureCollectionWithDuplicateImages,
+} from '@hazmapper/__fixtures__/featuresFixture';
 
 describe('featureTreeUtils', () => {
   describe('featureCollectionToFileNodeArray', () => {
@@ -32,6 +35,29 @@ describe('featureTreeUtils', () => {
       expect(result[0].children?.[1].children?.[0].nodeId).toBe('2');
     });
 
-    // Add more test cases as needed
+    it('should convert handle duplicate paths in tree structure', () => {
+      const mockFeatureCollection = featureCollectionWithDuplicateImages;
+
+      const result = featureCollectionToFileNodeArray(mockFeatureCollection);
+
+      /*
+       * Directory layout:
+       * ├── folder1
+       * │   ├── image1.JPG
+       * │   └── image2.JPG
+       * ├── image1.JPG
+       * └── image2.JPG
+       * */
+
+      expect(result).toHaveLength(3);
+      expect(result[0].name).toBe('folder1');
+      expect(result[1].name).toBe('image1.JPG');
+      expect(result[2].name).toBe('image1.JPG');
+
+      // folder1 contents
+      expect(result[0].children).toHaveLength(2);
+      expect(result[0].children?.[0].name).toBe('image1.JPG');
+      expect(result[0].children?.[1].name).toBe('image1.JPG');
+    });
   });
 });


### PR DESCRIPTION
## Overview: ##

Duplicate file paths were not being shown in feature tree

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

None

## Testing Steps: ##
1.  See unit tests
