### PR TITLE
hotfix: enable `preferCanvas` option in MapContainer

### DIFF
--- a/react/src/components/Map/Map.tsx
+++ b/react/src/components/Map/Map.tsx
@@ -134,6 +134,7 @@ const LeafletMap: React.FC<LeafletMapProps> = ({
       minZoom={MAP_CONFIG.minZoom}
       maxZoom={MAP_CONFIG.maxZoom}
       maxBounds={MAP_CONFIG.maxBounds}
+      preferCanvas={true}
     >
       {activeBaseLayers?.map((layer) =>
         layer.type === 'wms' ? (


### PR DESCRIPTION
## Overview: ##

This PR updates react-leaflet MapContainer configuration to enable preferCanvas for improved rendering performance with dense map features.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

None

## Testing Steps: ##
1. No testing needed but you could get a map with lots of non-point features and then check performance scrolling in the map with/without this change. and confirm that selecting works etc.
