### PR TITLE
task/WG-389-Asset-Panel-Questionnaire

### DIFF
--- a/react/src/__fixtures__/featuresFixture.ts
+++ b/react/src/__fixtures__/featuresFixture.ts
@@ -288,56 +288,46 @@ export const mockVideoFeature: Feature = {
   ],
 };
 
-export const mockQuestionnaireFeature : Feature = {
-  "id": 2466139,
-  "project_id": 94,
-  "type": "Feature",
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      -122.306436952,
-      47.653046488
-    ]
+export const mockQuestionnaireFeature: Feature = {
+  id: 2466139,
+  project_id: 94,
+  type: 'Feature',
+  geometry: {
+    type: 'Point',
+    coordinates: [-122.306436952, 47.653046488],
   },
-  "properties": {
-    "_hazmapper": {
-      "questionnaire": {
-        "assets": [
+  properties: {
+    _hazmapper: {
+      questionnaire: {
+        assets: [
           {
-            "filename": "Q11-Photo-001.jpg",
-            "coordinates": [
-              -122.30645555555556,
-              47.65306388888889
-            ]
+            filename: 'Q11-Photo-001.jpg',
+            coordinates: [-122.30645555555556, 47.65306388888889],
           },
           {
-            "filename": "Q12-Photo-001.jpg",
-            "coordinates": [
-              -122.30648611111111,
-              47.65299722222222
-            ]
+            filename: 'Q12-Photo-001.jpg',
+            coordinates: [-122.30648611111111, 47.65299722222222],
           },
           {
-            "filename": "Q13-Photo-001.jpg",
-            "coordinates": [
-              -122.3064611111111,
-              47.652975
-            ]
-          }
-        ]
-      }
-    }
+            filename: 'Q13-Photo-001.jpg',
+            coordinates: [-122.3064611111111, 47.652975],
+          },
+        ],
+      },
+    },
   },
-  "styles": {},
-  "assets": [
+  styles: {},
+  assets: [
     {
-      "id": 2037094,
-      "path": "94/816c47f4-b34d-4a30-b0d8-e92b11ba100c",
-      "uuid": "816c47f4-b34d-4a30-b0d8-e92b11ba100c",
-      "asset_type": "questionnaire",
-      "original_path": "project-3891343857756007955-242ac117-0001-012/RApp/asif27/Home/GNSS Base Station Setup (Copy 1) 1690582474191.rqa/GNSS Base Station Setup (Copy 1) 1690582474191.rq",
-      "original_name": null,
-      "display_path": "project-3891343857756007955-242ac117-0001-012/RApp/asif27/Home/GNSS Base Station Setup (Copy 1) 1690582474191.rqa/GNSS Base Station Setup (Copy 1) 1690582474191.rq"
-    }
-  ]
-}
+      id: 2037094,
+      path: '94/816c47f4-b34d-4a30-b0d8-e92b11ba100c',
+      uuid: '816c47f4-b34d-4a30-b0d8-e92b11ba100c',
+      asset_type: 'questionnaire',
+      original_path:
+        'project-3891343857756007955-242ac117-0001-012/RApp/asif27/Home/GNSS Base Station Setup (Copy 1) 1690582474191.rqa/GNSS Base Station Setup (Copy 1) 1690582474191.rq',
+      original_name: null,
+      display_path:
+        'project-3891343857756007955-242ac117-0001-012/RApp/asif27/Home/GNSS Base Station Setup (Copy 1) 1690582474191.rqa/GNSS Base Station Setup (Copy 1) 1690582474191.rq',
+    },
+  ],
+};

--- a/react/src/__fixtures__/featuresFixture.ts
+++ b/react/src/__fixtures__/featuresFixture.ts
@@ -287,3 +287,57 @@ export const mockVideoFeature: Feature = {
     },
   ],
 };
+
+export const mockQuestionnaireFeature : Feature = {
+  "id": 2466139,
+  "project_id": 94,
+  "type": "Feature",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [
+      -122.306436952,
+      47.653046488
+    ]
+  },
+  "properties": {
+    "_hazmapper": {
+      "questionnaire": {
+        "assets": [
+          {
+            "filename": "Q11-Photo-001.jpg",
+            "coordinates": [
+              -122.30645555555556,
+              47.65306388888889
+            ]
+          },
+          {
+            "filename": "Q12-Photo-001.jpg",
+            "coordinates": [
+              -122.30648611111111,
+              47.65299722222222
+            ]
+          },
+          {
+            "filename": "Q13-Photo-001.jpg",
+            "coordinates": [
+              -122.3064611111111,
+              47.652975
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "styles": {},
+  "assets": [
+    {
+      "id": 2037094,
+      "path": "94/816c47f4-b34d-4a30-b0d8-e92b11ba100c",
+      "uuid": "816c47f4-b34d-4a30-b0d8-e92b11ba100c",
+      "asset_type": "questionnaire",
+      "original_path": "project-3891343857756007955-242ac117-0001-012/RApp/asif27/Home/GNSS Base Station Setup (Copy 1) 1690582474191.rqa/GNSS Base Station Setup (Copy 1) 1690582474191.rq",
+      "original_name": null,
+      "display_path": "project-3891343857756007955-242ac117-0001-012/RApp/asif27/Home/GNSS Base Station Setup (Copy 1) 1690582474191.rqa/GNSS Base Station Setup (Copy 1) 1690582474191.rq"
+    }
+  ]
+}

--- a/react/src/components/AssetDetail/AssetDetail.module.css
+++ b/react/src/components/AssetDetail/AssetDetail.module.css
@@ -89,6 +89,7 @@ th {
 .caption {
   color: #1f5c7a;
   font-size: 0.8em;
+  padding-bottom: 0.8em;
 }
 .questionnaireImage {
   width: 100%;

--- a/react/src/components/AssetDetail/AssetDetail.module.css
+++ b/react/src/components/AssetDetail/AssetDetail.module.css
@@ -93,4 +93,5 @@ th {
 }
 .questionnaireImage {
   width: 100%;
+  height: 30em;
 }

--- a/react/src/components/AssetDetail/AssetDetail.module.css
+++ b/react/src/components/AssetDetail/AssetDetail.module.css
@@ -93,5 +93,4 @@ th {
 }
 .questionnaireImage {
   width: 100%;
-  height: 30em;
 }

--- a/react/src/components/AssetDetail/AssetDetail.module.css
+++ b/react/src/components/AssetDetail/AssetDetail.module.css
@@ -86,3 +86,11 @@ th {
   height: 35em;
   width: 100%;
 }
+.caption {
+  color: #1f5c7a;
+  font-size: 0.8em;
+}
+.questionnaireImage {
+  width: 100%;
+  height: 30em;
+}

--- a/react/src/components/AssetDetail/AssetDetail.test.tsx
+++ b/react/src/components/AssetDetail/AssetDetail.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import AssetDetail from './AssetDetail';
 import { mockImgFeature } from '@hazmapper/__fixtures__/featuresFixture';
+import AssetGeometry from './AssetGeometry';
 
 jest.mock('@hazmapper/hooks', () => ({
   useFeatureSelection: jest.fn(),
@@ -23,9 +24,16 @@ describe('AssetDetail', () => {
     isPublicView: false,
   };
 
-  it('renders all main components', () => {
+  it('renders all main components', async () => {
     const { getByText } = render(<AssetDetail {...AssetModalProps} />);
     const assetGeometry = screen.getByTestId('asset-geometry');
+    await act(async () => {
+      render(
+        <AssetGeometry
+          selectedFeature={mockImgFeature}
+        />
+      );
+    });
     // Check for title, button, and tables
     expect(getByText('Photo 4.jpg')).toBeDefined();
     expect(getByText('Download')).toBeDefined();

--- a/react/src/components/AssetDetail/AssetDetail.test.tsx
+++ b/react/src/components/AssetDetail/AssetDetail.test.tsx
@@ -28,11 +28,7 @@ describe('AssetDetail', () => {
     const { getByText } = render(<AssetDetail {...AssetModalProps} />);
     const assetGeometry = screen.getByTestId('asset-geometry');
     await act(async () => {
-      render(
-        <AssetGeometry
-          selectedFeature={mockImgFeature}
-        />
-      );
+      render(<AssetGeometry selectedFeature={mockImgFeature} />);
     });
     // Check for title, button, and tables
     expect(getByText('Photo 4.jpg')).toBeDefined();

--- a/react/src/components/AssetDetail/AssetDetail.tsx
+++ b/react/src/components/AssetDetail/AssetDetail.tsx
@@ -77,21 +77,36 @@ const AssetDetail: React.FC<AssetModalProps> = ({
             <tbody>
               {selectedFeature?.properties &&
               Object.keys(selectedFeature.properties).length > 0 ? (
-                Object.entries(selectedFeature.properties)
-                  .filter(([key]) => !key.startsWith('_hazmapper'))
-                  .sort(([keyA], [keyB]) => keyA.localeCompare(keyB)) // Alphabetizes metadata
-                  .map(([propKey, propValue]) => (
-                    <tr key={propKey}>
-                      <td>{_.startCase(propKey)}</td>
-                      <td>
-                        {propKey.startsWith('description') ? (
-                          <code>{propValue}</code>
-                        ) : (
-                          _.trim(JSON.stringify(propValue), '"')
-                        )}
-                      </td>
+                (() => {
+                  /* Function check that shows the "There are no metadata properties" 
+                  in any of these cases:
+                  - The properties object is empty or null
+                  - The properties object only contains keys that start with "_hazmapper"
+                  - The properties object exists but has no properties*/
+                  const filteredProperties = Object.entries(
+                    selectedFeature.properties
+                  )
+                    .filter(([key]) => !key.startsWith('_hazmapper'))
+                    .sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
+                  return filteredProperties.length > 0 ? (
+                    filteredProperties.map(([propKey, propValue]) => (
+                      <tr key={propKey}>
+                        <td>{_.startCase(propKey)}</td>
+                        <td>
+                          {propKey.startsWith('description') ? (
+                            <code>{propValue}</code>
+                          ) : (
+                            _.trim(JSON.stringify(propValue), '"')
+                          )}
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan={2}>There are no metadata properties.</td>
                     </tr>
-                  ))
+                  );
+                })()
               ) : (
                 <tr>
                   <td colSpan={2}>There are no metadata properties.</td>

--- a/react/src/components/AssetDetail/AssetDetail.tsx
+++ b/react/src/components/AssetDetail/AssetDetail.tsx
@@ -64,59 +64,61 @@ const AssetDetail: React.FC<AssetModalProps> = ({
           />
         </Suspense>
       </div>
-      <div className={styles.bottomSection}>
-        <div className={styles.metadataTable}>
-          <table>
-            <thead>
-              <tr>
-                <th colSpan={2} className="text-center">
-                  Metadata
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {selectedFeature?.properties &&
-              Object.keys(selectedFeature.properties).length > 0 ? (
-                (() => {
-                  /* Function check that shows the "There are no metadata properties" 
+      {featureType !== FeatureType.Questionnaire && (
+        <div className={styles.bottomSection}>
+          <div className={styles.metadataTable}>
+            <table>
+              <thead>
+                <tr>
+                  <th colSpan={2} className="text-center">
+                    Metadata
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {selectedFeature?.properties &&
+                Object.keys(selectedFeature.properties).length > 0 ? (
+                  (() => {
+                    /* Function check that shows the "There are no metadata properties" 
                   in any of these cases:
                   - The properties object is empty or null
                   - The properties object only contains keys that start with "_hazmapper"
                   - The properties object exists but has no properties*/
-                  const filteredProperties = Object.entries(
-                    selectedFeature.properties
-                  )
-                    .filter(([key]) => !key.startsWith('_hazmapper'))
-                    .sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
-                  return filteredProperties.length > 0 ? (
-                    filteredProperties.map(([propKey, propValue]) => (
-                      <tr key={propKey}>
-                        <td>{_.startCase(propKey)}</td>
-                        <td>
-                          {propKey.startsWith('description') ? (
-                            <code>{propValue}</code>
-                          ) : (
-                            _.trim(JSON.stringify(propValue), '"')
-                          )}
-                        </td>
+                    const filteredProperties = Object.entries(
+                      selectedFeature.properties
+                    )
+                      .filter(([key]) => !key.startsWith('_hazmapper'))
+                      .sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
+                    return filteredProperties.length > 0 ? (
+                      filteredProperties.map(([propKey, propValue]) => (
+                        <tr key={propKey}>
+                          <td>{_.startCase(propKey)}</td>
+                          <td>
+                            {propKey.startsWith('description') ? (
+                              <code>{propValue}</code>
+                            ) : (
+                              _.trim(JSON.stringify(propValue), '"')
+                            )}
+                          </td>
+                        </tr>
+                      ))
+                    ) : (
+                      <tr>
+                        <td colSpan={2}>There are no metadata properties.</td>
                       </tr>
-                    ))
-                  ) : (
-                    <tr>
-                      <td colSpan={2}>There are no metadata properties.</td>
-                    </tr>
-                  );
-                })()
-              ) : (
-                <tr>
-                  <td colSpan={2}>There are no metadata properties.</td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-          <AssetGeometry selectedFeature={selectedFeature} />
+                    );
+                  })()
+                ) : (
+                  <tr>
+                    <td colSpan={2}>There are no metadata properties.</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+            <AssetGeometry selectedFeature={selectedFeature} />
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/react/src/components/AssetDetail/AssetGeometry.test.tsx
+++ b/react/src/components/AssetDetail/AssetGeometry.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import GeometryAsset from './AssetGeometry';
+import AssetGeometry from './AssetGeometry';
 import { mockImgFeature } from '@hazmapper/__fixtures__/featuresFixture';
 
 jest.mock('@turf/turf', () => ({
@@ -20,7 +20,7 @@ describe('AssetGeometry', () => {
   };
 
   it('renders geometry for point on an image', () => {
-    const { getByText } = render(<GeometryAsset {...GeometryAssetProps} />);
+    const { getByText } = render(<AssetGeometry {...GeometryAssetProps} />);
     expect(getByText('Geometry: Point')).toBeDefined();
     expect(getByText('Latitude')).toBeDefined();
     expect(getByText('Longitude')).toBeDefined();

--- a/react/src/components/AssetDetail/AssetGeometry.tsx
+++ b/react/src/components/AssetDetail/AssetGeometry.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import _ from 'lodash';
 import * as turf from '@turf/turf';
 import { Feature, FeatureType } from '@hazmapper/types';
+import styles from './AssetDetail.module.css';
 
 interface AssetGeometryProps {
   selectedFeature: Feature;
@@ -18,7 +19,7 @@ const AssetGeometry: React.FC<AssetGeometryProps> = ({ selectedFeature }) => {
   const geometryType = selectedFeature.geometry.type;
 
   return (
-    <>
+    <div className={styles.metadataTable}>
       {geometryType === FeatureType.Point && (
         <table>
           <thead>
@@ -111,7 +112,7 @@ const AssetGeometry: React.FC<AssetGeometryProps> = ({ selectedFeature }) => {
           </tbody>
         </table>
       )}
-    </>
+    </div>
   );
 };
 

--- a/react/src/components/AssetDetail/AssetQuestionnaire.test.tsx
+++ b/react/src/components/AssetDetail/AssetQuestionnaire.test.tsx
@@ -14,11 +14,7 @@ jest.mock('antd', () => ({
   Carousel: forwardRef(({ children }: any, ref: any) => {
     // Assign the mock methods to the ref
     React.useImperativeHandle(ref, () => mockCarouselRef);
-    return (
-      <div data-testid="mock-carousel">
-        {children}
-      </div>
-    );
+    return <div data-testid="mock-carousel">{children}</div>;
   }),
   Space: ({ children }: any) => <div data-testid="mock-space">{children}</div>,
   Flex: ({ children }: any) => <div data-testid="mock-flex">{children}</div>,
@@ -26,10 +22,7 @@ jest.mock('antd', () => ({
 
 jest.mock('@tacc/core-components', () => ({
   Button: ({ children, onClick, iconNameBefore }: any) => (
-    <button 
-      onClick={onClick}
-      data-testid={`button-${iconNameBefore}`}
-    >
+    <button onClick={onClick} data-testid={`button-${iconNameBefore}`}>
       {iconNameBefore}
       {children}
     </button>
@@ -60,15 +53,24 @@ describe('AssetQuestionnaire', () => {
     });
 
     const images = screen.getAllByRole('img');
-    expect(images).toHaveLength(mockQuestionnaireFeature?.properties?._hazmapper.questionnaire.assets.length);
+    expect(images).toHaveLength(
+      mockQuestionnaireFeature?.properties?._hazmapper.questionnaire.assets
+        .length
+    );
 
-    mockQuestionnaireFeature?.properties?._hazmapper.questionnaire.assets.forEach((asset, index) => {
-      const image = images[index];
-      const expectedPreviewPath = `${mockFeatureSource}/${asset.filename}`.replace(/\.([^.]+)$/, '.preview.$1');
-      
-      expect(image.getAttribute('src')).toBe(expectedPreviewPath);
-      expect(image.getAttribute('alt')).toBe(asset.filename);
-    });
+    mockQuestionnaireFeature?.properties?._hazmapper.questionnaire.assets.forEach(
+      (asset, index) => {
+        const image = images[index];
+        const expectedPreviewPath =
+          `${mockFeatureSource}/${asset.filename}`.replace(
+            /\.([^.]+)$/,
+            '.preview.$1'
+          );
+
+        expect(image.getAttribute('src')).toBe(expectedPreviewPath);
+        expect(image.getAttribute('alt')).toBe(asset.filename);
+      }
+    );
   });
 
   it('renders navigation buttons', async () => {
@@ -78,7 +80,7 @@ describe('AssetQuestionnaire', () => {
 
     const prevButton = screen.getByTestId('button-push-left');
     const nextButton = screen.getByTestId('button-push-right');
-    
+
     expect(prevButton).toBeTruthy();
     expect(nextButton).toBeTruthy();
   });
@@ -88,10 +90,12 @@ describe('AssetQuestionnaire', () => {
       setup();
     });
 
-    mockQuestionnaireFeature?.properties?._hazmapper.questionnaire.assets.forEach((asset) => {
-      const caption = screen.getByText(asset.filename);
-      expect(caption).toBeTruthy();
-    });
+    mockQuestionnaireFeature?.properties?._hazmapper.questionnaire.assets.forEach(
+      (asset) => {
+        const caption = screen.getByText(asset.filename);
+        expect(caption).toBeTruthy();
+      }
+    );
   });
 
   it('handles carousel navigation', async () => {

--- a/react/src/components/AssetDetail/AssetQuestionnaire.test.tsx
+++ b/react/src/components/AssetDetail/AssetQuestionnaire.test.tsx
@@ -11,8 +11,7 @@ const mockCarouselRef = {
 
 // Mock the antd components used in AssetQuestionnaire
 jest.mock('antd', () => ({
-  Carousel: forwardRef(({ children }: any, ref: any) => {
-    // Assign the mock methods to the ref
+  Carousel: forwardRef(function Carousel({ children }: any, ref: any) {
     React.useImperativeHandle(ref, () => mockCarouselRef);
     return <div data-testid="mock-carousel">{children}</div>;
   }),

--- a/react/src/components/AssetDetail/AssetQuestionnaire.test.tsx
+++ b/react/src/components/AssetDetail/AssetQuestionnaire.test.tsx
@@ -1,0 +1,140 @@
+import React, { forwardRef } from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { mockQuestionnaireFeature } from '@hazmapper/__fixtures__/featuresFixture';
+import AssetQuestionnaire from './AssetQuestionnaire';
+
+// Create a mock ref implementation for Carousel
+const mockCarouselRef = {
+  next: jest.fn(),
+  prev: jest.fn(),
+};
+
+// Mock the antd components used in AssetQuestionnaire
+jest.mock('antd', () => ({
+  Carousel: forwardRef(({ children }: any, ref: any) => {
+    // Assign the mock methods to the ref
+    React.useImperativeHandle(ref, () => mockCarouselRef);
+    return (
+      <div data-testid="mock-carousel">
+        {children}
+      </div>
+    );
+  }),
+  Space: ({ children }: any) => <div data-testid="mock-space">{children}</div>,
+  Flex: ({ children }: any) => <div data-testid="mock-flex">{children}</div>,
+}));
+
+jest.mock('@tacc/core-components', () => ({
+  Button: ({ children, onClick, iconNameBefore }: any) => (
+    <button 
+      onClick={onClick}
+      data-testid={`button-${iconNameBefore}`}
+    >
+      {iconNameBefore}
+      {children}
+    </button>
+  ),
+}));
+
+describe('AssetQuestionnaire', () => {
+  const mockFeatureSource = 'https://example.com/api/assets/123';
+
+  beforeEach(() => {
+    // Clear mock function calls before each test
+    mockCarouselRef.next.mockClear();
+    mockCarouselRef.prev.mockClear();
+  });
+
+  const setup = () => {
+    return render(
+      <AssetQuestionnaire
+        feature={mockQuestionnaireFeature}
+        featureSource={mockFeatureSource}
+      />
+    );
+  };
+
+  it('renders all images from the questionnaire assets', async () => {
+    await act(async () => {
+      setup();
+    });
+
+    const images = screen.getAllByRole('img');
+    expect(images).toHaveLength(mockQuestionnaireFeature?.properties?._hazmapper.questionnaire.assets.length);
+
+    mockQuestionnaireFeature?.properties?._hazmapper.questionnaire.assets.forEach((asset, index) => {
+      const image = images[index];
+      const expectedPreviewPath = `${mockFeatureSource}/${asset.filename}`.replace(/\.([^.]+)$/, '.preview.$1');
+      
+      expect(image.getAttribute('src')).toBe(expectedPreviewPath);
+      expect(image.getAttribute('alt')).toBe(asset.filename);
+    });
+  });
+
+  it('renders navigation buttons', async () => {
+    await act(async () => {
+      setup();
+    });
+
+    const prevButton = screen.getByTestId('button-push-left');
+    const nextButton = screen.getByTestId('button-push-right');
+    
+    expect(prevButton).toBeTruthy();
+    expect(nextButton).toBeTruthy();
+  });
+
+  it('displays image filenames as captions', async () => {
+    await act(async () => {
+      setup();
+    });
+
+    mockQuestionnaireFeature?.properties?._hazmapper.questionnaire.assets.forEach((asset) => {
+      const caption = screen.getByText(asset.filename);
+      expect(caption).toBeTruthy();
+    });
+  });
+
+  it('handles carousel navigation', async () => {
+    await act(async () => {
+      setup();
+    });
+
+    const prevButton = screen.getByTestId('button-push-left');
+    const nextButton = screen.getByTestId('button-push-right');
+
+    await act(async () => {
+      fireEvent.click(nextButton);
+    });
+    expect(mockCarouselRef.next).toHaveBeenCalled();
+
+    await act(async () => {
+      fireEvent.click(prevButton);
+    });
+    expect(mockCarouselRef.prev).toHaveBeenCalled();
+  });
+
+  it('renders "No images available" when there are no assets', async () => {
+    const emptyFeature = {
+      ...mockQuestionnaireFeature,
+      properties: {
+        _hazmapper: {
+          questionnaire: {
+            assets: [],
+          },
+        },
+      },
+    };
+
+    await act(async () => {
+      render(
+        <AssetQuestionnaire
+          feature={emptyFeature}
+          featureSource={mockFeatureSource}
+        />
+      );
+    });
+
+    const noImagesText = screen.getByText('No images available');
+    expect(noImagesText).toBeTruthy();
+  });
+});

--- a/react/src/components/AssetDetail/AssetQuestionnaire.tsx
+++ b/react/src/components/AssetDetail/AssetQuestionnaire.tsx
@@ -1,0 +1,82 @@
+import React, { useRef } from 'react';
+import { Feature, QuestionnaireAsset } from '@hazmapper/types';
+import { Carousel, Space, Flex } from 'antd';
+import { Button } from '@tacc/core-components';
+import styles from './AssetDetail.module.css';
+import type { CarouselRef } from 'antd/es/carousel';
+
+type QuestionnaireProps = {
+  feature: Feature;
+  featureSource: string;
+};
+
+export const AssetQuestionnaire: React.FC<QuestionnaireProps> = ({
+  feature,
+  featureSource,
+}) => {
+  const carouselRef = useRef<CarouselRef>(null);
+
+  const processAssetImages = (): QuestionnaireAsset[] => {
+    if (feature.properties?._hazmapper?.questionnaire?.assets) {
+      return feature.properties._hazmapper.questionnaire.assets.map((asset) => {
+        const pathToFullImage = `${featureSource}/${asset.filename}`;
+        const fileExtension = pathToFullImage.substring(
+          pathToFullImage.lastIndexOf('.')
+        );
+        const pathWithoutExtension = pathToFullImage.substring(
+          0,
+          pathToFullImage.lastIndexOf('.')
+        );
+        const pathToPreviewImage = `${pathWithoutExtension}.preview${fileExtension}`;
+
+        return {
+          filename: asset.filename,
+          coordinates: asset.coordinates,
+          path: pathToFullImage,
+          previewPath: pathToPreviewImage,
+        };
+      });
+    }
+    return [];
+  };
+
+  const assetImages = processAssetImages();
+
+  const next = () => {
+    carouselRef.current?.next();
+  };
+
+  const previous = () => {
+    carouselRef.current?.prev();
+  };
+
+  if (assetImages.length === 0) {
+    return <div>No images available</div>;
+  }
+
+  return (
+    <div>
+      <Carousel ref={carouselRef} dots={false} draggable={true}>
+        {assetImages.map((asset, index) => (
+          <div key={`${asset.filename}-${index}`}>
+            <Flex gap="small" vertical>
+              <img
+                className={styles.questionnaireImage}
+                src={asset.previewPath}
+                alt={asset.filename}
+              />
+              <div className={styles.caption}>{asset.filename}</div>
+            </Flex>
+          </div>
+        ))}
+      </Carousel>
+
+      <Space size="large">
+        <Button iconNameBefore="push-left" onClick={previous}></Button>
+        <Button iconNameBefore="push-right" onClick={next}></Button>
+      </Space>
+    </div>
+  );
+};
+
+export default AssetQuestionnaire;

--- a/react/src/components/AssetDetail/AssetRenderer.tsx
+++ b/react/src/components/AssetDetail/AssetRenderer.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Feature, FeatureType, getFeatureType } from '@hazmapper/types';
 import { SectionMessage } from '@tacc/core-components';
 import AssetPointCloud from './AssetPointCloud';
+import AssetQuestionnaire from './AssetQuestionnaire';
 
 interface AssetRendererProps {
   selectedFeature: Feature;
@@ -30,7 +31,12 @@ const AssetRenderer: React.FC<AssetRendererProps> = ({
     case FeatureType.PointCloud:
       return <AssetPointCloud featureSource={featureSource} />;
     case FeatureType.Questionnaire:
-      return <div>source={featureSource}</div>;
+      return (
+        <AssetQuestionnaire
+          feature={selectedFeature}
+          featureSource={featureSource}
+        />
+      );
     case FeatureType.GeometryCollection:
     default:
       if (isGeometry(featureType)) {

--- a/react/src/types/feature.ts
+++ b/react/src/types/feature.ts
@@ -141,3 +141,9 @@ export interface FeatureFileNode {
   featureType: FeatureTypeNullable;
   children?: FeatureFileNode[];
 }
+export interface QuestionnaireAsset {
+  filename: string;
+  coordinates: any;
+  path: string;
+  previewPath: string;
+}


### PR DESCRIPTION
## Overview: ##
Adds questionnaire carousel, styles, and tests

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-389](https://tacc-main.atlassian.net/browse/WG-389)

## Summary of Changes: ##
- Adds questionnaire asset detail component
- Adds questionnaire test and fixture
- Fixes issue with questionnaires not showing "There are no metadata properties" message in table (See comment in code [here](https://github.com/TACC-Cloud/hazmapper/blob/e22a933dc3e846208717c9fc5968ea412b62a098/react/src/components/AssetDetail/AssetDetail.tsx#L81))
- Adds table styles to geometry to fix scrolling behavior of geometry metadata table
- Implements custom buttons for questionnaire carousel. Ant Design forward and back buttons only appear on image and require very specific css to change 
- Creates QuestionnaireAsset type 

## Testing Steps: ##
1. Go to [the RApp Questionnaire Testing map](http://localhost:4200/project/42591a9a-172f-4675-a7b5-875f5f319e5c). You should already be added to the project but ping me if you can't access. 
2. View questionnaires and make sure if there are no associated images, that state is handled. Otherwise, a carousel shows all the associated assets to that questionnaire. NOTE: Questionnaire files are .rq files and have a clipboard icon next to them


## UI Photos:
### Carousel of images associated with questionnaire
<img width="426" alt="Screenshot 2025-01-10 at 6 04 48 PM" src="https://github.com/user-attachments/assets/f5b1e2cd-fa89-48a2-baa5-86a07b79d589" />

<img width="421" alt="Screenshot 2025-01-10 at 6 05 38 PM" src="https://github.com/user-attachments/assets/f8bc0ae7-2bac-4438-ab34-651c6a07815b" />

###No images associated with questionnaire
<img width="419" alt="Screenshot 2025-01-10 at 6 06 31 PM" src="https://github.com/user-attachments/assets/23b7a985-4df2-4bc3-8359-f299b01a5771" />


## Notes: ##
Follow on - View button for questionnaire modal in [WG-411](https://tacc-main.atlassian.net/browse/WG-411)