### PR TITLE
WIP - WG-387 - Import from Designsafe Modal

### DIFF
--- a/react/src/components/AssetsPanel/AssetsPanel.test.tsx
+++ b/react/src/components/AssetsPanel/AssetsPanel.test.tsx
@@ -37,7 +37,7 @@ describe('AssetsPanel', () => {
     const { getByText } = render(<AssetsPanel {...defaultProps} />);
 
     // Check for the presence of buttons
-    expect(getByText('Import from DesignSafe TODO/WG-387')).toBeDefined();
+    expect(getByText('Import from DesignSafe')).toBeDefined();
     expect(getByText('Export to GeoJSON')).toBeDefined();
   });
 

--- a/react/src/components/AssetsPanel/AssetsPanel.tsx
+++ b/react/src/components/AssetsPanel/AssetsPanel.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './AssetsPanel.module.css';
 import FeatureFileTree from '@hazmapper/components/FeatureFileTree';
 import { FeatureCollection, Project } from '@hazmapper/types';
 import { Button } from '@tacc/core-components';
 import { useFeatures } from '@hazmapper/hooks';
+import FileBrowserModal from '../FileBrowserModal/FileBrowserModal';
 
 const getFilename = (projectName: string) => {
   // Convert to lowercase filename based on projectName
@@ -78,10 +79,34 @@ const AssetsPanel: React.FC<Props> = ({
   featureCollection,
   project,
 }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const toggleModal = () => {
+    setIsModalOpen(!isModalOpen);
+  };
+
+  const allowedFileExtensions = [
+    'shp',
+    'jpg',
+    'jpeg',
+    'json',
+    'geojson',
+    'gpx',
+    'rq',
+    'png',
+  ];
+
   return (
     <div className={styles.root}>
       <div className={styles.topSection}>
-        <Button>Import from DesignSafe TODO/WG-387</Button>
+        <FileBrowserModal
+          isOpen={isModalOpen}
+          toggle={toggleModal}
+          allowedFileExtensions={allowedFileExtensions}
+        />
+        <Button onClick={toggleModal} type="secondary" iconNameBefore="add">
+          Import from DesignSafe
+        </Button>
       </div>
       <div className={styles.middleSection}>
         <FeatureFileTree

--- a/react/src/components/AssetsPanel/AssetsPanel.tsx
+++ b/react/src/components/AssetsPanel/AssetsPanel.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import styles from './AssetsPanel.module.css';
 import FeatureFileTree from '@hazmapper/components/FeatureFileTree';
-import { FeatureCollection, Project } from '@hazmapper/types';
+import { FeatureCollection, Project, TapisFilePath } from '@hazmapper/types';
 import { Button } from '@tacc/core-components';
-import { useFeatures } from '@hazmapper/hooks';
+import { useFeatures, useImportFeature } from '@hazmapper/hooks';
 import FileBrowserModal from '../FileBrowserModal/FileBrowserModal';
 
 const getFilename = (projectName: string) => {
@@ -14,14 +14,16 @@ const getFilename = (projectName: string) => {
 
 interface DownloadFeaturesButtonProps {
   project: Project;
+  isPublicView: boolean;
 }
 
 const DownloadFeaturesButton: React.FC<DownloadFeaturesButtonProps> = ({
   project,
+  isPublicView,
 }) => {
   const { isLoading: isDownloading, refetch: triggerDownload } = useFeatures({
     projectId: project.id,
-    isPublicView: project.public,
+    isPublicView: isPublicView,
     assetTypes: [], // Empty array to get all features
     options: {
       enabled: false, // Only fetch when triggered by user clicking button
@@ -81,6 +83,13 @@ const AssetsPanel: React.FC<Props> = ({
 }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  const { mutate: importFeatureFiles } = useImportFeature(project.id);
+
+  const handleFileImport = (files: TapisFilePath[]) => {
+    importFeatureFiles({ files });
+    setIsModalOpen(false);
+  };
+
   const toggleModal = () => {
     setIsModalOpen(!isModalOpen);
   };
@@ -102,6 +111,7 @@ const AssetsPanel: React.FC<Props> = ({
         <FileBrowserModal
           isOpen={isModalOpen}
           toggle={toggleModal}
+          onImported={handleFileImport}
           allowedFileExtensions={allowedFileExtensions}
         />
         <Button onClick={toggleModal} type="secondary" iconNameBefore="add">
@@ -116,7 +126,7 @@ const AssetsPanel: React.FC<Props> = ({
         />
       </div>
       <div className={styles.bottomSection}>
-        <DownloadFeaturesButton project={project} />
+        <DownloadFeaturesButton project={project} isPublicView={isPublicView} />
       </div>
     </div>
   );

--- a/react/src/components/FileBrowserModal/FileBrowserModal.test.tsx
+++ b/react/src/components/FileBrowserModal/FileBrowserModal.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import FileBrowserModal from './FileBrowserModal';
+import { renderInTest } from '@hazmapper/test/testUtil';
+import '@testing-library/jest-dom';
+
+// TODO see if we don't have to mock chonky
+jest.mock('chonky', () => ({
+  FileBrowser: jest.fn(({ children, onFileAction }) => (
+    <div
+      onClick={onFileAction}
+      onKeyDown={onFileAction}
+      role="button"
+      tabIndex={0}
+    >
+      {children}
+    </div>
+  )),
+  FileNavbar: jest.fn(() => <div>Mock FileNavbar</div>),
+  FileList: jest.fn(() => <div>Mock FileList</div>),
+  ChonkyActions: {
+    EnableListView: { id: 'enable-list-view' },
+    OpenFiles: { id: 'open-files' },
+    MouseClickFile: { id: 'mouse-click-file' },
+    ChangeSelection: { id: 'change-selection' },
+  },
+}));
+
+describe('FileBrowserModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    toggle: jest.fn(),
+    onImported: jest.fn(),
+    allowedFileExtensions: ['.foo', '.bar'],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly when open', async () => {
+    renderInTest(<FileBrowserModal {...defaultProps} />);
+
+    // Wait for systems data to load
+    await waitFor(() => {
+      expect(screen.getByText('Select Files')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText('Allowed file types: .foo, .bar')
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        'Note: Only files are selectable, not folders. Double-click on a folder to navigate into it.'
+      )
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+    expect(screen.getByText('Import')).toBeInTheDocument();
+
+    const importButton = screen
+      .getByText('Import')
+      .closest('button') as HTMLButtonElement;
+    expect(importButton).toBeDisabled();
+  });
+
+  it('handles cancel action correctly', async () => {
+    renderInTest(<FileBrowserModal {...defaultProps} />);
+
+    // Wait for systems data to load
+    await waitFor(() => {
+      expect(screen.getByText('Select Files')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(defaultProps.toggle).toHaveBeenCalled();
+  });
+});

--- a/react/src/components/FileBrowserModal/FileBrowserModal.tsx
+++ b/react/src/components/FileBrowserModal/FileBrowserModal.tsx
@@ -43,9 +43,6 @@ const FileBrowserModal = ({
       title={<Header style={{ fontSize: '2rem' }}>Select Files</Header>}
       open={isOpen}
       onCancel={handleClose}
-      zIndex={
-        2000 /* TODO define somewhere to be reusable in different modals */
-      }
       footer={[
         <Text key="fileCount" type="secondary" style={{ marginRight: 16 }}>
           {selectedFiles.length > 0 && `${selectedFiles.length} files selected`}

--- a/react/src/components/FileBrowserModal/FileBrowserModal.tsx
+++ b/react/src/components/FileBrowserModal/FileBrowserModal.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Modal, Button, Layout, Typography } from 'antd';
+import { FileListing } from '../Files';
+
+type FileBrowserModalProps = {
+  isOpen: boolean;
+  toggle: () => void;
+  allowedFileExtensions?: string[];
+};
+
+const { Content, Header } = Layout;
+const { Text } = Typography;
+
+const FileBrowserModal = ({
+  isOpen,
+  toggle: parentToggle,
+  allowedFileExtensions = [],
+}: FileBrowserModalProps) => {
+  const handleClose = () => {
+    parentToggle();
+  };
+
+  return (
+    <Modal
+      title={<Header style={{ fontSize: '2rem' }}>Select Files</Header>}
+      open={isOpen}
+      onCancel={handleClose}
+      footer={[
+        <Button key="closeModalButton" onClick={handleClose}>
+          Cancel
+        </Button>,
+        <Button key="importFilesButton" htmlType="submit" type="primary">
+          Import
+        </Button>,
+      ]}
+      width={800}
+    >
+      <Content>
+        <Text type="secondary">
+          Allowed file types: shp, jpg, jpeg, json, geojson, gpx, rq
+        </Text>
+        <br />
+        <Text type="secondary">
+          Note: Only files are selectable, not folders. Double-click on a folder
+          to navigate into it.
+        </Text>
+        <div style={{ marginTop: '1rem' }}>
+          <FileListing
+            disableSelection={false}
+            showPublicSystems={true}
+            allowedFileExtensions={allowedFileExtensions}
+          />
+        </div>
+      </Content>
+    </Modal>
+  );
+};
+
+export default FileBrowserModal;

--- a/react/src/components/FileBrowserModal/FileBrowserModal.tsx
+++ b/react/src/components/FileBrowserModal/FileBrowserModal.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Modal, Button, Layout, Typography } from 'antd';
 import { FileListing } from '../Files';
+import { File, TapisFilePath } from '@hazmapper/types';
+import { convertFilesToTapisPaths } from '@hazmapper/utils/fileUtils';
 
 type FileBrowserModalProps = {
   isOpen: boolean;
   toggle: () => void;
-  allowedFileExtensions?: string[];
+  onImported?: (files: TapisFilePath[]) => void;
+  allowedFileExtensions: string[];
 };
 
 const { Content, Header } = Layout;
@@ -14,10 +17,25 @@ const { Text } = Typography;
 const FileBrowserModal = ({
   isOpen,
   toggle: parentToggle,
+  onImported,
   allowedFileExtensions = [],
 }: FileBrowserModalProps) => {
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+
   const handleClose = () => {
     parentToggle();
+  };
+
+  const handleFileSelect = (files: File[]) => {
+    setSelectedFiles(files);
+  };
+
+  const handleImport = () => {
+    if (onImported) {
+      const tapisFilePaths = convertFilesToTapisPaths(selectedFiles);
+      onImported(tapisFilePaths);
+    }
+    handleClose();
   };
 
   return (
@@ -25,20 +43,34 @@ const FileBrowserModal = ({
       title={<Header style={{ fontSize: '2rem' }}>Select Files</Header>}
       open={isOpen}
       onCancel={handleClose}
+      zIndex={
+        2000 /* TODO define somewhere to be reusable in different modals */
+      }
       footer={[
+        <Text key="fileCount" type="secondary" style={{ marginRight: 16 }}>
+          {selectedFiles.length > 0 && `${selectedFiles.length} files selected`}
+        </Text>,
         <Button key="closeModalButton" onClick={handleClose}>
           Cancel
         </Button>,
-        <Button key="importFilesButton" htmlType="submit" type="primary">
+        <Button
+          key="importFilesButton"
+          htmlType="submit"
+          type="primary"
+          onClick={handleImport}
+          disabled={selectedFiles.length === 0} // Disable if no files are selected
+        >
           Import
         </Button>,
       ]}
       width={800}
     >
       <Content>
-        <Text type="secondary">
-          Allowed file types: shp, jpg, jpeg, json, geojson, gpx, rq
-        </Text>
+        {allowedFileExtensions?.length && (
+          <Text type="secondary">
+            Allowed file types: {allowedFileExtensions.join(', ')}
+          </Text>
+        )}
         <br />
         <Text type="secondary">
           Note: Only files are selectable, not folders. Double-click on a folder
@@ -49,6 +81,7 @@ const FileBrowserModal = ({
             disableSelection={false}
             showPublicSystems={true}
             allowedFileExtensions={allowedFileExtensions}
+            onFileSelect={handleFileSelect}
           />
         </div>
       </Content>

--- a/react/src/components/FileBrowserModal/index.ts
+++ b/react/src/components/FileBrowserModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FileBrowserModal';

--- a/react/src/components/Files/FileListing.test.tsx
+++ b/react/src/components/Files/FileListing.test.tsx
@@ -25,6 +25,7 @@ jest.mock('../../utils/fileUtils', () => ({
   serializeToChonkyFile: jest.fn(),
 }));
 
+// TODO see if we don't have to mock chonky
 jest.mock('chonky', () => {
   const actualChonky = jest.requireActual('chonky');
   return {

--- a/react/src/hooks/features/index.ts
+++ b/react/src/hooks/features/index.ts
@@ -1,4 +1,5 @@
 export { useDeleteFeature } from './useDeleteFeature';
+export { useImportFeature } from './useImportFeature';
 export { useImportFeatureAsset } from './useImportFeatureAsset';
 export {
   useFeatures,

--- a/react/src/hooks/features/useImportFeature.ts
+++ b/react/src/hooks/features/useImportFeature.ts
@@ -1,0 +1,18 @@
+import { usePost } from '../../requests';
+import {
+  ApiService,
+  TapisFilePath,
+  GeoapiMessageAcceptedResponse,
+} from '@hazmapper/types';
+
+type ImportFeature = {
+  files: TapisFilePath[];
+};
+
+export const useImportFeature = (projectId: number) => {
+  const endpoint = `/projects/${projectId}/features/files/import/`;
+  return usePost<ImportFeature, GeoapiMessageAcceptedResponse>({
+    endpoint,
+    apiService: ApiService.Geoapi,
+  });
+};

--- a/react/src/test/handlers.ts
+++ b/react/src/test/handlers.ts
@@ -30,7 +30,7 @@ export const designsafe_project = http.get(
 
 // GeoAPI Projects GET - handles both list and single project (i.e query is "?uuid=uuid")
 export const geoapi_get_projects = http.get(
-  `${testDevConfiguration.geoapiUrl}/projects/`,
+  `${testDevConfiguration.geoapiUrl}/:projects_or_project_public_segment/`,
   ({ request }) => {
     const url = new URL(request.url);
     const uuid = url.searchParams.get('uuid');
@@ -49,7 +49,7 @@ export const geoapi_get_projects = http.get(
 
 // GeoAPI Project Features GET
 export const geoapi_project_features = http.get(
-  `${testDevConfiguration.geoapiUrl}/projects/:projectId/features/`,
+  `${testDevConfiguration.geoapiUrl}/:projects_or_project_public_segment/:projectId/features/`,
   () => HttpResponse.json(featureCollection, { status: 200 })
 );
 
@@ -61,7 +61,7 @@ export const geoapi_project_users = http.get(
 
 // GeoAPI Project Tile Servers GET
 export const geoapi_project_tile_servers = http.get(
-  `${testDevConfiguration.geoapiUrl}/projects/:projectId/tile-servers/`,
+  `${testDevConfiguration.geoapiUrl}/:projects_or_project_public_segment/:projectId/tile-servers/`,
   () => HttpResponse.json(tileServerLayers, { status: 200 })
 );
 

--- a/react/src/types/file.ts
+++ b/react/src/types/file.ts
@@ -1,3 +1,4 @@
+// Tapis file (from interacting with Tapis directly, i.e. file listings)
 export interface File {
   name: string;
   path: string;
@@ -7,6 +8,18 @@ export interface File {
   mimeType: string;
   type: string;
   url: string;
+}
+
+export interface IFileImportRequest {
+  system_id: string;
+  path: string;
+}
+
+// Tapis file's system and path (from interacting with Geoapi backend)
+// TODO look at backend; so similar to IFileImportRequest but system instead of system_id. our backend is inconsistent.
+export interface TapisFilePath {
+  system: string;
+  path: string;
 }
 
 export interface IFileImportRequest {

--- a/react/src/utils/fileUtils.ts
+++ b/react/src/utils/fileUtils.ts
@@ -1,5 +1,5 @@
 import { FileData } from 'chonky';
-import { File } from '../types';
+import { TapisFilePath, File } from '@hazmapper/types';
 
 export const serializeToChonkyFile = (
   file: File,
@@ -19,3 +19,21 @@ export const serializeToChonkyFile = (
     file.type === 'dir' ||
     allowedFileExtensions.includes(file.name.split('.').pop() || ''),
 });
+
+export const convertFilesToTapisPaths = (files: File[]): TapisFilePath[] => {
+  return files.map((file) => {
+    // Remove the "tapis://" prefix
+    const urlWithoutPrefix = file.url.replace('tapis://', '');
+
+    // Split the remaining string at the first forward slash
+    // The first part will be the system, everything after is the path
+    const firstSlashIndex = urlWithoutPrefix.indexOf('/');
+    const system = urlWithoutPrefix.substring(0, firstSlashIndex);
+    const path = urlWithoutPrefix.substring(firstSlashIndex);
+
+    return {
+      system,
+      path,
+    };
+  });
+};


### PR DESCRIPTION
## Overview: ##

Modal for importing assets from designsafe

## PR Status: ##

* [x] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-387](https://tacc-main.atlassian.net/browse/WG-387)

## Summary of Changes: ##

## Testing Steps: ##
1. Load a map and click Import from Designsafe button

## UI Photos:

<img width="1914" alt="Screenshot 2025-01-31 at 11 43 26 AM" src="https://github.com/user-attachments/assets/2d8a8f3b-c85d-472c-90d7-841b8c5a6434" />


## Notes: ##

TODO: 

* [x] - Add functionality for Import Button
* [x] - Add tests for modal component
