### PR TITLE
Hotfix/allow user to set which DesignSafe site to use in local dev

### DIFF
--- a/react/src/hooks/environment/getLocalAppConfiguration.ts
+++ b/react/src/hooks/environment/getLocalAppConfiguration.ts
@@ -21,7 +21,7 @@ export const getLocalAppConfiguration = (
     localDevelopmentConfiguration.designSafePortal ??
     DesignSafePortalEnvironment.PPRD;
 
-  // Check for possible mismatch on prod or staging as those deployed envionments are matched up with DS prod and pprd
+  // Check for possible mismatches in Geoapi production or Geoapi staging, as these deployed environments correspond to DS prod and pprd, respectively.
   if (
     (localDevelopmentConfiguration.geoapiBackend ===
       GeoapiBackendEnvironment.Production &&

--- a/react/src/hooks/environment/getLocalAppConfiguration.ts
+++ b/react/src/hooks/environment/getLocalAppConfiguration.ts
@@ -5,6 +5,7 @@ import {
   AppConfiguration,
   MapillaryConfiguration,
   DesignSafePortalEnvironment,
+  GeoapiBackendEnvironment,
 } from '@hazmapper/types';
 
 /**
@@ -16,12 +17,27 @@ export const getLocalAppConfiguration = (
   basePath: string,
   mapillaryConfig: MapillaryConfiguration
 ): AppConfiguration => {
+  const designSafePortal =
+    localDevelopmentConfiguration.designSafePortal ??
+    DesignSafePortalEnvironment.PPRD;
+
+  // Check for possible mismatch on prod or staging as those deployed envionments are matched up with DS prod and pprd
+  if (
+    (localDevelopmentConfiguration.geoapiBackend ===
+      GeoapiBackendEnvironment.Production &&
+      designSafePortal !== DesignSafePortalEnvironment.Production) ||
+    (localDevelopmentConfiguration.geoapiBackend ===
+      GeoapiBackendEnvironment.Staging &&
+      designSafePortal !== DesignSafePortalEnvironment.PPRD)
+  ) {
+    const msg = `Mismatch detected: geoapiBackend is '${localDevelopmentConfiguration.geoapiBackend}', but designSafePortal is '${designSafePortal}'.`;
+    throw new Error(msg);
+  }
+
   const appConfig: AppConfiguration = {
     basePath: basePath,
     geoapiUrl: getGeoapiUrl(localDevelopmentConfiguration.geoapiBackend),
-    designsafePortalUrl: getDesignsafePortalUrl(
-      DesignSafePortalEnvironment.PPRD
-    ),
+    designsafePortalUrl: getDesignsafePortalUrl(designSafePortal),
     tapisUrl: 'https://designsafe.tapis.io',
     mapillary: mapillaryConfig,
     taggitUrl: origin + '/taggit-staging',
@@ -31,5 +47,6 @@ export const getLocalAppConfiguration = (
     'MLY|5156692464392931|6be48c9f4074f4d486e0c42a012b349f';
   appConfig.mapillary.clientToken =
     'MLY|5156692464392931|4f1118aa1b06f051a44217cb56bedf79';
+
   return appConfig;
 };

--- a/react/src/secret_local.example.ts
+++ b/react/src/secret_local.example.ts
@@ -1,5 +1,10 @@
-import { GeoapiBackendEnvironment, LocalAppConfiguration } from './types';
+import {
+  DesignSafePortalEnvironment,
+  GeoapiBackendEnvironment,
+  LocalAppConfiguration,
+} from './types';
 
 export const localDevelopmentConfiguration: LocalAppConfiguration = {
-  geoapiBackend: GeoapiBackendEnvironment.Production,
+  geoapiBackend: GeoapiBackendEnvironment.Staging,
+  designSafePortal: DesignSafePortalEnvironment.PPRD,
 };

--- a/react/src/types/environment.ts
+++ b/react/src/types/environment.ts
@@ -45,6 +45,9 @@ export enum ApiService {
 export interface LocalAppConfiguration {
   /* The type of backend environment (production, staging, development, or local) */
   geoapiBackend: GeoapiBackendEnvironment;
+
+  /** Type of GeoAPI service. Defaults to PPRD if not provided */
+  designSafePortal?: DesignSafePortalEnvironment;
 }
 
 /**


### PR DESCRIPTION
## Overview: ##

Allow user to set which DesignSafe site to use in local dev

Note: LocalAppConfiguration.designSafePortal is optional and defaults to PPRD.

## PR Status: ##

* [X] Ready.
