### PR TITLE
task/WG-425: Fix asset panel css

### DIFF
--- a/react/src/components/AssetsPanel/AssetsPanel.module.css
+++ b/react/src/components/AssetsPanel/AssetsPanel.module.css
@@ -25,5 +25,5 @@
 
 .middleSection > div {
   flex: 1;
-  overflow: auto;
+  max-height: 95%;
 }

--- a/react/src/components/AssetsPanel/AssetsPanel.tsx
+++ b/react/src/components/AssetsPanel/AssetsPanel.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import styles from './AssetsPanel.module.css';
 import FeatureFileTree from '@hazmapper/components/FeatureFileTree';
 import { FeatureCollection, Project, TapisFilePath } from '@hazmapper/types';
-import { Button } from '@tacc/core-components';
+import { Flex, Layout, Button as AntButton } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
 import { useFeatures, useImportFeature } from '@hazmapper/hooks';
 import FileBrowserModal from '../FileBrowserModal/FileBrowserModal';
 
@@ -50,9 +51,13 @@ const DownloadFeaturesButton: React.FC<DownloadFeaturesButtonProps> = ({
   });
 
   return (
-    <Button isLoading={isDownloading} onClick={() => triggerDownload()}>
+    <AntButton
+      loading={isDownloading}
+      onClick={() => triggerDownload()}
+      type="primary"
+    >
       Export to GeoJSON
-    </Button>
+    </AntButton>
   );
 };
 
@@ -105,30 +110,37 @@ const AssetsPanel: React.FC<Props> = ({
     'png',
   ];
 
+  const { Content, Header, Footer } = Layout;
+
   return (
-    <div className={styles.root}>
-      <div className={styles.topSection}>
-        <FileBrowserModal
-          isOpen={isModalOpen}
-          toggle={toggleModal}
-          onImported={handleFileImport}
-          allowedFileExtensions={allowedFileExtensions}
-        />
-        <Button onClick={toggleModal} type="secondary" iconNameBefore="add">
-          Import from DesignSafe
-        </Button>
-      </div>
-      <div className={styles.middleSection}>
-        <FeatureFileTree
-          projectId={project.id}
-          isPublicView={isPublicView}
-          featureCollection={featureCollection}
-        />
-      </div>
-      <div className={styles.bottomSection}>
-        <DownloadFeaturesButton project={project} isPublicView={isPublicView} />
-      </div>
-    </div>
+    <>
+      <Flex vertical className={styles.root} flex={1}>
+        <Header className={styles.topSection}>
+          <AntButton onClick={toggleModal} icon={<PlusOutlined />}>
+            Import from DesignSafe
+          </AntButton>
+        </Header>
+        <Content className={styles.middleSection}>
+          <FeatureFileTree
+            projectId={project.id}
+            isPublicView={isPublicView}
+            featureCollection={featureCollection}
+          />
+        </Content>
+        <Footer className={styles.bottomSection}>
+          <DownloadFeaturesButton
+            project={project}
+            isPublicView={isPublicView}
+          />
+        </Footer>
+      </Flex>
+      <FileBrowserModal
+        isOpen={isModalOpen}
+        toggle={toggleModal}
+        onImported={handleFileImport}
+        allowedFileExtensions={allowedFileExtensions}
+      />
+    </>
   );
 };
 

--- a/react/src/components/Panel/Panel.tsx
+++ b/react/src/components/Panel/Panel.tsx
@@ -11,7 +11,7 @@ const Panel: React.FC<LayoutProps & { panelTitle: string }> = ({
 
   return (
     <Layout {...props}>
-      <Flex vertical className={styles.root}>
+      <Flex vertical className={styles.root} flex={1}>
         <Header className={styles.header}>{panelTitle}</Header>
         <Content>{children}</Content>
       </Flex>

--- a/react/src/pages/MapProject/MapProject.module.css
+++ b/react/src/pages/MapProject/MapProject.module.css
@@ -5,19 +5,12 @@
   height: 100vh;
 }
 
-.container {
-  height: calc(
-    100vh - var(--hazmapper-header-navbar-height) -
-      var(--hazmapper-control-bar-height)
-  );
-  width: 100%;
-  display: flex;
-  flex: 1;
-}
-
 .panelContainer {
   width: var(--hazmapper-panel-width);
-  height: 100%;
+  height: calc(
+    100% - var(--hazmapper-header-navbar-height) -
+      var(--hazmapper-control-bar-height)
+  );
   background-color: var(--global-color-primary--xx-light);
   position: fixed;
   left: var(--hazmapper-panel-navbar-width);

--- a/react/src/pages/MapProject/MapProject.tsx
+++ b/react/src/pages/MapProject/MapProject.tsx
@@ -238,7 +238,6 @@ const LoadedMapProject: React.FC<LoadedMapProject> = ({
             <Sider width="auto">
               <Flex
                 style={{
-                  overflowY: 'auto',
                   height: '100%',
                 }}
               >


### PR DESCRIPTION
## Overview: ##

Fixes css preventing asset panel from scrolling properly.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-425](https://tacc-main.atlassian.net/browse/WG-425)

## Summary of Changes: ##

- makes FeatureFileTree scrollable by setting max-height
- replaces AssetPanel buttons with Ant buttons
- fixes base panel height

## Testing Steps: ##
1. Go to http://localhost:4200/project/db8f8bc8-4a48-4fd4-9009-8a201d19f81a?panel=Assets with prod settings, or another project with lots of assets
2. Shrink your window, and confirm you can see all buttons if you scroll

## UI Photos:
![Screenshot 2025-02-13 at 12 24 29 PM](https://github.com/user-attachments/assets/e1fec7e0-a185-447b-bf2c-e67146a63649)
![Screenshot 2025-02-13 at 12 24 47 PM](https://github.com/user-attachments/assets/5e6e3be4-646c-419e-8141-74678a09e4d5)

