### PR TITLE
Task/WG-428-import-asset-to-feature

### DIFF
--- a/react/src/components/AssetDetail/AssetButton.tsx
+++ b/react/src/components/AssetDetail/AssetButton.tsx
@@ -7,7 +7,7 @@ import {
   IFileImportRequest,
   TapisFilePath,
 } from '@hazmapper/types';
-import { useImportFeatureAsset /*, useNotification*/ } from '@hazmapper/hooks';
+import { useImportFeatureAsset, useNotification } from '@hazmapper/hooks';
 import FileBrowserModal from '../FileBrowserModal/FileBrowserModal';
 import { IMPORTABLE_FEATURE_ASSET_TYPES } from '@hazmapper/utils/fileUtils';
 
@@ -28,8 +28,7 @@ const AssetButton: React.FC<AssetButtonProps> = ({
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const featureType = getFeatureType(selectedFeature);
   const projectId = selectedFeature.project_id;
-  /* Uncomment when WG-422 polling is merged 
-  const notification = useNotification();*/
+  const notification = useNotification();
   const featureId = selectedFeature.id;
   const { mutate: importFeatureAsset, isPending: isImporting } =
     useImportFeatureAsset(projectId, featureId);
@@ -43,16 +42,15 @@ const AssetButton: React.FC<AssetButtonProps> = ({
       importFeatureAsset(importData, {
         onSuccess: () => {
           setIsModalOpen(false);
-          /*Uncomment these notifications when WG-422 is merged
           notification.success({
-            description: `Your asset import for feature ${selectedFeature.id} started.`,
-          });*/
+            description: `Your asset import for feature ${selectedFeature.id} was successful.`,
+          });
         },
-        onError: (/*error*/) => {
+        onError: (error) => {
           setIsModalOpen(false);
-          /*notification.success({
+          notification.success({
             description: `There was an error importing your asset for feature ${selectedFeature.id}. Error: ${error}`,
-          });*/
+          });
         },
       });
     }
@@ -91,6 +89,7 @@ const AssetButton: React.FC<AssetButtonProps> = ({
           onImported={handleSubmit}
           allowedFileExtensions={IMPORTABLE_FEATURE_ASSET_TYPES}
           isSingleSelectMode={true}
+          singleSelectErrorMessage="Adding multiple assets to a feature is not supported."
         />
       )}
     </>

--- a/react/src/components/AssetDetail/AssetButton.tsx
+++ b/react/src/components/AssetDetail/AssetButton.tsx
@@ -31,11 +31,8 @@ const AssetButton: React.FC<AssetButtonProps> = ({
   /* Uncomment when WG-422 polling is merged 
   const notification = useNotification();*/
   const featureId = selectedFeature.id;
-  const {
-    mutate: importFeatureAsset,
-    isPending: isImporting,
-    isSuccess: isImportingSuccess,
-  } = useImportFeatureAsset(projectId, featureId);
+  const { mutate: importFeatureAsset, isPending: isImporting } =
+    useImportFeatureAsset(projectId, featureId);
 
   const handleSubmit = (files: TapisFilePath[]) => {
     for (const file of files) {
@@ -82,7 +79,7 @@ const AssetButton: React.FC<AssetButtonProps> = ({
           type="primary"
           onClick={() => setIsModalOpen(true)}
           isLoading={isImporting}
-          disabled={isImportingSuccess}
+          disabled={isImporting}
         >
           Add Asset from DesignSafe
         </Button>

--- a/react/src/components/AssetDetail/AssetButton.tsx
+++ b/react/src/components/AssetDetail/AssetButton.tsx
@@ -45,7 +45,7 @@ const AssetButton: React.FC<AssetButtonProps> = ({
           setIsModalOpen(false);
           /*Uncomment these notifications when WG-422 is merged
           notification.success({
-            description: `Your asset was successful imported for feature ${selectedFeature.id}`,
+            description: `Your asset import for feature ${selectedFeature.id} started.`,
           });*/
         },
         onError: (/*error*/) => {
@@ -90,6 +90,7 @@ const AssetButton: React.FC<AssetButtonProps> = ({
           toggle={() => setIsModalOpen(false)}
           onImported={handleSubmit}
           allowedFileExtensions={IMPORTABLE_FEATURE_ASSET_TYPES}
+          isSingleSelectMode={true}
         />
       )}
     </>

--- a/react/src/components/AssetDetail/AssetButton.tsx
+++ b/react/src/components/AssetDetail/AssetButton.tsx
@@ -1,9 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 import DOMPurify from 'dompurify';
 import { Button } from '@tacc/core-components';
 import { Feature, FeatureType } from '@hazmapper/types';
-import { getFeatureType, IFileImportRequest } from '@hazmapper/types';
-import { useImportFeatureAsset } from '@hazmapper/hooks';
+import {
+  getFeatureType,
+  IFileImportRequest,
+  TapisFilePath,
+} from '@hazmapper/types';
+import { useImportFeatureAsset /*, useNotification*/ } from '@hazmapper/hooks';
+import FileBrowserModal from '../FileBrowserModal/FileBrowserModal';
+import { IMPORTABLE_FEATURE_ASSET_TYPES } from '@hazmapper/utils/fileUtils';
 
 type AssetButtonProps = {
   selectedFeature: Feature;
@@ -19,9 +25,11 @@ const AssetButton: React.FC<AssetButtonProps> = ({
   onQuestionnaireClick,
 }) => {
   const pointCloudURL = DOMPurify.sanitize(featureSource + '/index.html');
-
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const featureType = getFeatureType(selectedFeature);
   const projectId = selectedFeature.project_id;
+  /* Uncomment when WG-422 polling is merged 
+  const notification = useNotification();*/
   const featureId = selectedFeature.id;
   const {
     mutate: importFeatureAsset,
@@ -29,17 +37,28 @@ const AssetButton: React.FC<AssetButtonProps> = ({
     isSuccess: isImportingSuccess,
   } = useImportFeatureAsset(projectId, featureId);
 
-  const handleImportFeatureAsset = (importData: IFileImportRequest) => {
-    importFeatureAsset(importData);
-  };
-  const handleSubmit = () => {
-    const importData: IFileImportRequest = {
-      /*TODO Replace with passed in values from
-      FileBrowserModal. These are hardcoded to test.*/
-      system_id: 'project-4072868216578445806-242ac117-0001-012',
-      path: 'images_good/image.jpg',
-    };
-    handleImportFeatureAsset(importData);
+  const handleSubmit = (files: TapisFilePath[]) => {
+    for (const file of files) {
+      const importData: IFileImportRequest = {
+        system_id: file.system,
+        path: file.path,
+      };
+      importFeatureAsset(importData, {
+        onSuccess: () => {
+          setIsModalOpen(false);
+          /*Uncomment these notifications when WG-422 is merged
+          notification.success({
+            description: `Your asset was successful imported for feature ${selectedFeature.id}`,
+          });*/
+        },
+        onError: (/*error*/) => {
+          setIsModalOpen(false);
+          /*notification.success({
+            description: `There was an error importing your asset for feature ${selectedFeature.id}. Error: ${error}`,
+          });*/
+        },
+      });
+    }
   };
 
   return (
@@ -61,12 +80,20 @@ const AssetButton: React.FC<AssetButtonProps> = ({
         //TODO
         <Button
           type="primary"
-          onClick={handleSubmit}
+          onClick={() => setIsModalOpen(true)}
           isLoading={isImporting}
           disabled={isImportingSuccess}
         >
           Add Asset from DesignSafe
         </Button>
+      )}
+      {isModalOpen && (
+        <FileBrowserModal
+          isOpen={isModalOpen}
+          toggle={() => setIsModalOpen(false)}
+          onImported={handleSubmit}
+          allowedFileExtensions={IMPORTABLE_FEATURE_ASSET_TYPES}
+        />
       )}
     </>
   );

--- a/react/src/components/AssetDetail/AssetDetail.tsx
+++ b/react/src/components/AssetDetail/AssetDetail.tsx
@@ -53,18 +53,24 @@ const AssetDetail: React.FC<AssetDetailProps> = ({
       </div>
       <div className={styles.middleSection}>
         <Suspense fallback={<LoadingSpinner />}>
-          <div className={styles.assetContainer}>
-            <AssetRenderer
-              selectedFeature={selectedFeature}
-              featureSource={featureSource}
-            />
-          </div>
-          <AssetButton
-            selectedFeature={selectedFeature}
-            featureSource={featureSource}
-            isPublicView={isPublicView}
-            onQuestionnaireClick={onQuestionnaireClick}
-          />
+          {featureType == FeatureType.Collection ? (
+            <div>Collections of assets not supported</div>
+          ) : (
+            <>
+              <div className={styles.assetContainer}>
+                <AssetRenderer
+                  selectedFeature={selectedFeature}
+                  featureSource={featureSource}
+                />
+              </div>
+              <AssetButton
+                selectedFeature={selectedFeature}
+                featureSource={featureSource}
+                isPublicView={isPublicView}
+                onQuestionnaireClick={onQuestionnaireClick}
+              />
+            </>
+          )}
         </Suspense>
       </div>
       {featureType !== FeatureType.Questionnaire && (

--- a/react/src/components/FileBrowserModal/FileBrowserModal.tsx
+++ b/react/src/components/FileBrowserModal/FileBrowserModal.tsx
@@ -57,7 +57,7 @@ const FileBrowserModal = ({
         <Text key="fileCount" type="secondary" style={{ marginRight: 16 }}>
           {isSingleSelectMode && selectedFiles.length > 1 && (
             <SectionMessage type="error">
-              Adding multiple asset to a feature is not supported.
+              Adding multiple assets to a feature is not supported.
             </SectionMessage>
           )}
           {selectedFiles.length > 0 && `${selectedFiles.length} files selected`}

--- a/react/src/components/FileBrowserModal/FileBrowserModal.tsx
+++ b/react/src/components/FileBrowserModal/FileBrowserModal.tsx
@@ -10,6 +10,7 @@ type FileBrowserModalProps = {
   toggle: () => void;
   onImported?: (files: TapisFilePath[]) => void;
   allowedFileExtensions: string[];
+  singleSelectErrorMessage?: string;
   isSingleSelectMode?: boolean;
 };
 
@@ -22,6 +23,7 @@ const FileBrowserModal = ({
   onImported,
   allowedFileExtensions = [],
   isSingleSelectMode = false,
+  singleSelectErrorMessage = '',
 }: FileBrowserModalProps) => {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const handleClose = () => {
@@ -42,7 +44,11 @@ const FileBrowserModal = ({
 
   return (
     <Modal
-      title={<Header style={{ fontSize: '2rem' }}>Select Files</Header>}
+      title={
+        <Header style={{ fontSize: '2rem' }}>
+          Select File{!isSingleSelectMode && 's'}
+        </Header>
+      }
       open={isOpen}
       onCancel={handleClose}
       footer={[
@@ -50,13 +56,11 @@ const FileBrowserModal = ({
           <Flex vertical justify="space-evenly">
             {isSingleSelectMode && selectedFiles.length > 1 && (
               <SectionMessage type="error">
-                Adding multiple assets to a feature is not supported.
+                {singleSelectErrorMessage}
               </SectionMessage>
             )}
             <Flex justify="space-between">
-              {isSingleSelectMode && (
-                <div>You may only import one asset per feature.</div>
-              )}
+              {isSingleSelectMode && <div>You may only import one file.</div>}
               {selectedFiles.length > 0 &&
                 `${selectedFiles.length} files selected`}
             </Flex>

--- a/react/src/components/FileBrowserModal/FileBrowserModal.tsx
+++ b/react/src/components/FileBrowserModal/FileBrowserModal.tsx
@@ -30,8 +30,6 @@ const FileBrowserModal = ({
     );
   }, [allowedFileExtensions]);
 
-  console.log(isSingleSelectMode);
-
   const handleClose = () => {
     parentToggle();
   };

--- a/react/src/components/FileBrowserModal/FileBrowserModal.tsx
+++ b/react/src/components/FileBrowserModal/FileBrowserModal.tsx
@@ -23,7 +23,6 @@ const FileBrowserModal = ({
   allowedFileExtensions = [],
 }: FileBrowserModalProps) => {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
-  const [isMultiSelectError, setIsMultiSelectError] = useState<boolean>(false);
   const isSingleSelectMode = useMemo(() => {
     return (
       JSON.stringify(allowedFileExtensions.sort()) ===
@@ -42,10 +41,6 @@ const FileBrowserModal = ({
   };
 
   const handleImport = () => {
-    setIsMultiSelectError(false);
-    if (isSingleSelectMode && selectedFiles.length > 1) {
-      setIsMultiSelectError(true);
-    }
     if (onImported) {
       const tapisFilePaths = convertFilesToTapisPaths(selectedFiles);
       onImported(tapisFilePaths);

--- a/react/src/components/FileBrowserModal/FileBrowserModal.tsx
+++ b/react/src/components/FileBrowserModal/FileBrowserModal.tsx
@@ -1,9 +1,8 @@
-import React, { useState, useMemo } from 'react';
-import { Modal, Button, Layout, Typography } from 'antd';
+import React, { useState } from 'react';
+import { Modal, Button, Layout, Typography, Flex } from 'antd';
 import { FileListing } from '../Files';
 import { File, TapisFilePath } from '@hazmapper/types';
 import { convertFilesToTapisPaths } from '@hazmapper/utils/fileUtils';
-import { IMPORTABLE_FEATURE_ASSET_TYPES } from '@hazmapper/utils/fileUtils';
 import { SectionMessage } from '@tacc/core-components';
 
 type FileBrowserModalProps = {
@@ -11,6 +10,7 @@ type FileBrowserModalProps = {
   toggle: () => void;
   onImported?: (files: TapisFilePath[]) => void;
   allowedFileExtensions: string[];
+  isSingleSelectMode?: boolean;
 };
 
 const { Content, Header } = Layout;
@@ -21,15 +21,9 @@ const FileBrowserModal = ({
   toggle: parentToggle,
   onImported,
   allowedFileExtensions = [],
+  isSingleSelectMode = false,
 }: FileBrowserModalProps) => {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
-  const isSingleSelectMode = useMemo(() => {
-    return (
-      JSON.stringify(allowedFileExtensions.sort()) ===
-      JSON.stringify(IMPORTABLE_FEATURE_ASSET_TYPES.sort())
-    );
-  }, [allowedFileExtensions]);
-
   const handleClose = () => {
     parentToggle();
   };
@@ -53,12 +47,20 @@ const FileBrowserModal = ({
       onCancel={handleClose}
       footer={[
         <Text key="fileCount" type="secondary" style={{ marginRight: 16 }}>
-          {isSingleSelectMode && selectedFiles.length > 1 && (
-            <SectionMessage type="error">
-              Adding multiple assets to a feature is not supported.
-            </SectionMessage>
-          )}
-          {selectedFiles.length > 0 && `${selectedFiles.length} files selected`}
+          <Flex vertical justify="space-evenly">
+            {isSingleSelectMode && selectedFiles.length > 1 && (
+              <SectionMessage type="error">
+                Adding multiple assets to a feature is not supported.
+              </SectionMessage>
+            )}
+            <Flex justify="space-between">
+              {isSingleSelectMode && (
+                <div>You may only import one asset per feature.</div>
+              )}
+              {selectedFiles.length > 0 &&
+                `${selectedFiles.length} files selected`}
+            </Flex>
+          </Flex>
         </Text>,
         <Button key="closeModalButton" onClick={handleClose}>
           Cancel
@@ -87,7 +89,7 @@ const FileBrowserModal = ({
         <br />
         <Text type="secondary">
           Note: Only files are selectable, not folders. Double-click on a folder
-          to navigate into it.
+          to navigate into it.{' '}
         </Text>
         <div style={{ marginTop: '1rem' }}>
           <FileListing

--- a/react/src/components/QuestionnaireModal/questionnaireBuilder.ts
+++ b/react/src/components/QuestionnaireModal/questionnaireBuilder.ts
@@ -1070,7 +1070,7 @@ class Question {
       section.questions.push(this);
       // add to question map
       this.parent_template.question_map[this.template_question_num] = this;
-      his.parent_template.question_id_map[this.id] = this;
+      this.parent_template.question_id_map[this.id] = this;
     }
   }
 

--- a/react/src/hooks/features/useImportFeatureAsset.ts
+++ b/react/src/hooks/features/useImportFeatureAsset.ts
@@ -1,10 +1,27 @@
 import { usePost } from '../../requests';
+import { useQueryClient } from '@tanstack/react-query';
 import { ApiService, Feature, IFileImportRequest } from '@hazmapper/types';
+import { KEY_USE_FEATURES } from './useFeatures';
+
+export const KEY_USE_FEATURE_ASSET = 'featureAsset';
 
 export const useImportFeatureAsset = (projectId: number, featureId: number) => {
+  const queryClient = useQueryClient();
   const endpoint = `/projects/${projectId}/features/${featureId}/assets/`;
   return usePost<IFileImportRequest, Feature>({
     endpoint,
     apiService: ApiService.Geoapi,
+    options: {
+      onSuccess: () => {
+        // Invalidate the main features query to get updated feature list
+        queryClient.invalidateQueries({
+          queryKey: [KEY_USE_FEATURES],
+        });
+        // Invalidate any queries related to this specific feature's assets
+        queryClient.invalidateQueries({
+          queryKey: [KEY_USE_FEATURE_ASSET, featureId],
+        });
+      },
+    },
   });
 };

--- a/react/src/hooks/features/useImportFeatureAsset.ts
+++ b/react/src/hooks/features/useImportFeatureAsset.ts
@@ -3,8 +3,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { ApiService, Feature, IFileImportRequest } from '@hazmapper/types';
 import { KEY_USE_FEATURES } from './useFeatures';
 
-export const KEY_USE_FEATURE_ASSET = 'featureAsset';
-
 export const useImportFeatureAsset = (projectId: number, featureId: number) => {
   const queryClient = useQueryClient();
   const endpoint = `/projects/${projectId}/features/${featureId}/assets/`;
@@ -14,12 +12,9 @@ export const useImportFeatureAsset = (projectId: number, featureId: number) => {
     options: {
       onSuccess: () => {
         // Invalidate the main features query to get updated feature list
+        // This isn't done in a celery task, so onSuccess works to invalidate
         queryClient.invalidateQueries({
           queryKey: [KEY_USE_FEATURES],
-        });
-        // Invalidate any queries related to this specific feature's assets
-        queryClient.invalidateQueries({
-          queryKey: [KEY_USE_FEATURE_ASSET, featureId],
         });
       },
     },


### PR DESCRIPTION
## Overview: ##

Links import modal to Add Asset button in AssetDetail component

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-428](https://tacc-main.atlassian.net/browse/WG-428)

## Summary of Changes: ##
- Adds missing t in this for questionnaire builder (issue on staging)
- Adds check to see if importing to a feature, only allow one file to be selected.
- Added  specific query keys for cache invalidation in the useImportFeatureAsset hook:

1. KEY_USE_FEATURES for the main features list
2. [KEY_USE_FEATURE_ASSET, featureId] for feature-specific asset queries


## Testing Steps: ##
1. Create a map
4. Import a geojson to a map
5. Add an asset to that feature using the Add Asset from DesignSafe button
6. Make sure the icon in Asset panel changes to new file type
7. Make sure asset Detail changes to new asset
8. Check that you cannot import more than one asset to a feature

## UI Photos:

## Notes: ##
