### PR TITLE
fix/WG-436: use system path during project creation

### DIFF
--- a/react/src/components/CreateMapModal/CreateMapModal.tsx
+++ b/react/src/components/CreateMapModal/CreateMapModal.tsx
@@ -142,7 +142,7 @@ const CreateMapModal = ({ isOpen, closeModal }: CreateMapModalProps) => {
       description: values.description,
       system_file: values.systemFile,
       system_id: values.systemId,
-      system_path: `/${userData.username}`,
+      system_path: values.systemPath,
       watch_content: values.syncFolder,
       watch_users: values.syncFolder,
     };

--- a/react/src/components/CreateMapModal/CreateMapModal.tsx
+++ b/react/src/components/CreateMapModal/CreateMapModal.tsx
@@ -86,7 +86,7 @@ const CreateMapModal = ({ isOpen, closeModal }: CreateMapModalProps) => {
       setValue('systemFile', systemFilename);
       oldSystemFilename.current = systemFilename;
     }
-  }, [mapName]);
+  }, [getValues, mapName, setValue]);
 
   const handleClose = () => {
     setErrorMessage('');

--- a/react/src/components/ManageMapProjectPanel/SaveTabContent.tsx
+++ b/react/src/components/ManageMapProjectPanel/SaveTabContent.tsx
@@ -29,7 +29,7 @@ const SaveTabContent: React.FC<SaveTabProps> = ({ project }) => {
 
     if (project.system_id) {
       if (project.system_id.startsWith('project')) {
-        dsFolderHref = `${dsDataDepotUrl}projects/${dsProj?.value.projectId}${project.system_path}`;
+        dsFolderHref = `${dsDataDepotUrl}projects/${dsProj?.value.projectId}/${project.system_path}`;
 
         if (project.system_file) {
           dsProjectHref = `${dsDataDepotUrl}projects/${dsProj?.value.projectId}`;

--- a/react/src/components/ManageMapProjectPanel/SaveTabContent.tsx
+++ b/react/src/components/ManageMapProjectPanel/SaveTabContent.tsx
@@ -98,9 +98,9 @@ const SaveTabContent: React.FC<SaveTabProps> = ({ project }) => {
                   rel="noreferrer"
                   style={{ padding: 0 }}
                 >
-                  {dsProj?.value.projectId}
+                  {dsProj.value.projectId}
                   {' | '}
-                  {project.name}
+                  {dsProj.value.title}
                 </Button>
               ) : (
                 <Button
@@ -110,7 +110,7 @@ const SaveTabContent: React.FC<SaveTabProps> = ({ project }) => {
                   rel="noreferrer"
                   style={{ padding: 0 }}
                 >
-                  {project.system_id}
+                  My Data
                 </Button>
               )}
             </>


### PR DESCRIPTION
## Overview: ##

Fix system path during project creation. 

This PR also makes some small changes to the display of the projects' system/path in the manage panel.

## PR Status: ##

* [X] Ready

## Related Jira tickets: ##

* [WG-436](https://tacc-main.atlassian.net/browse/WG-436)

## Testing Steps: ##
1. Create a new map in subfolder in My Data or in a project
2. Confirm that this works as expected by checking POST or the links or the location of the .hazmapper file. Also, check the display/links of related DS project are correct in the Manage Panel.
