### PR TITLE
Testing Session UI/UX fixes

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -30,7 +30,6 @@
         "leaflet": "^1.9.4",
         "leaflet.markercluster": "^1.5.3",
         "react": "^18.3.1",
-        "react-datepicker": "^7.6.0",
         "react-dom": "^18.3.1",
         "react-esri-leaflet": "^2.0.1",
         "react-hook-form": "^7.54.2",
@@ -4034,6 +4033,7 @@
       "version": "1.6.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
       "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "optional": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.9"
       }
@@ -4042,29 +4042,17 @@
       "version": "1.6.13",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
       "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "optional": true,
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
         "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/react": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.4.tgz",
-      "integrity": "sha512-05mXdkUiVh8NCEcYKQ2C9SV9IkZ9k/dFtYmaEIN2riLv80UHoXylgBM76cgPJYfLJM3dJz7UE5MOVH0FypMd2Q==",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.2",
-        "@floating-ui/utils": "^0.2.9",
-        "tabbable": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
       }
     },
     "node_modules/@floating-ui/react-dom": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
       "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "optional": true,
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
       },
@@ -4076,7 +4064,8 @@
     "node_modules/@floating-ui/utils": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "optional": true
     },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "1.11.4",
@@ -12864,14 +12853,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -13660,6 +13641,8 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "optional": true,
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -23420,20 +23403,6 @@
         "react-dom": ">=16.8.0"
       }
     },
-    "node_modules/react-datepicker": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-7.6.0.tgz",
-      "integrity": "sha512-9cQH6Z/qa4LrGhzdc3XoHbhrxNcMi9MKjZmYgF/1MNNaJwvdSjv3Xd+jjvrEEbKEf71ZgCA3n7fQbdwd70qCRw==",
-      "dependencies": {
-        "@floating-ui/react": "^0.27.0",
-        "clsx": "^2.1.1",
-        "date-fns": "^3.6.0"
-      },
-      "peerDependencies": {
-        "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
-      }
-    },
     "node_modules/react-display-name": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/react-display-name/-/react-display-name-0.2.5.tgz",
@@ -25544,11 +25513,6 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
-    },
-    "node_modules/tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/tar": {
       "version": "6.2.1",

--- a/react/package.json
+++ b/react/package.json
@@ -54,7 +54,6 @@
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "react": "^18.3.1",
-    "react-datepicker": "^7.6.0",
     "react-dom": "^18.3.1",
     "react-esri-leaflet": "^2.0.1",
     "react-hook-form": "^7.54.2",

--- a/react/src/components/DeleteMapModal/DeleteMapModal.test.tsx
+++ b/react/src/components/DeleteMapModal/DeleteMapModal.test.tsx
@@ -91,13 +91,17 @@ describe('DeleteMapModal', () => {
 
     it('should disable delete button for non-deletable projects', async () => {
       await renderComponent(nonDeletableProjectMock);
-      const deleteButton = screen.getByText('Delete') as HTMLButtonElement;
+      const deleteButton = screen.getByTestId(
+        'delete-map-button'
+      ) as HTMLButtonElement;
       expect(deleteButton.disabled).toBe(true);
     });
 
     it('should enable delete button for deletable projects', async () => {
       await renderComponent();
-      const deleteButton = screen.getByText('Delete') as HTMLButtonElement;
+      const deleteButton = screen.getByTestId(
+        'delete-map-button'
+      ) as HTMLButtonElement;
       expect(deleteButton.disabled).toBe(false);
     });
 

--- a/react/src/components/DeleteMapModal/DeleteMapModal.tsx
+++ b/react/src/components/DeleteMapModal/DeleteMapModal.tsx
@@ -58,6 +58,7 @@ const DeleteMapModal = ({
       okButtonProps={{
         loading: isDeletingProject,
         disabled: isSuccess || !project?.deletable,
+        'data-testid': 'delete-map-button',
       }}
     >
       <Flex vertical style={{ paddingBottom: 20 }}>

--- a/react/src/components/DeleteMapModal/DeleteMapModal.tsx
+++ b/react/src/components/DeleteMapModal/DeleteMapModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
-import { Button, SectionMessage } from '@tacc/core-components';
+import { Modal, Layout, Flex, Alert } from 'antd';
 import { useNavigate } from 'react-router-dom';
 import { Project } from '@hazmapper/types';
 import { useDeleteProject } from '@hazmapper/hooks/projects/';
@@ -26,6 +25,9 @@ const DeleteMapModal = ({
     isError,
     isSuccess,
   } = useDeleteProject();
+
+  const { Header } = Layout;
+
   const handleClose = () => {
     parentToggle();
   };
@@ -46,45 +48,55 @@ const DeleteMapModal = ({
   };
 
   return (
-    <Modal size="lg" isOpen={isOpen} toggle={handleClose}>
-      <ModalHeader toggle={handleClose}>
-        Delete Map: {project?.name}{' '}
-      </ModalHeader>
-      <ModalBody>
+    <Modal
+      open={isOpen}
+      onCancel={handleClose}
+      title={<Header>Delete Map: {project?.name}</Header>}
+      onOk={handleDeleteProject}
+      okText="Delete"
+      cancelText={isSuccess ? 'Close' : 'Cancel'}
+      okButtonProps={{
+        loading: isDeletingProject,
+        disabled: isSuccess || !project?.deletable,
+      }}
+    >
+      <Flex vertical style={{ paddingBottom: 20 }}>
         {project?.deletable ? (
-          <>
-            Are you sure you want to delete this map? All associated features,
-            metadata, and saved files will be deleted.
-            {project?.public && <b> Note that this is a public map. </b>}
-            <br />
-            <b>
-              <u>This cannot be undone.</u>
-            </b>
-          </>
+          <Alert
+            type="warning"
+            message={
+              <span>
+                Are you sure you want to delete this map? All associated
+                features, metadata, and saved files will be deleted.
+                <br />
+                <br />
+                {project?.public && (
+                  <b>
+                    {' '}
+                    Note that this is a public map.
+                    <br />
+                    <br />
+                  </b>
+                )}
+                <b>
+                  <u>This cannot be undone.</u>
+                </b>
+              </span>
+            }
+          />
         ) : (
-          'You don’t have permission to delete this map.'
+          "You don't have permission to delete this map."
         )}
-      </ModalBody>
-      <ModalFooter className="justify-content-start">
-        <Button size="short" type="secondary" onClick={handleClose}>
-          {isSuccess ? 'Close' : 'Cancel'}
-        </Button>
-        <Button
-          size="short"
-          type="primary"
-          attr="submit"
-          isLoading={isDeletingProject}
-          onClick={handleDeleteProject}
-          disabled={isSuccess || !project?.deletable}
-        >
-          Delete
-        </Button>
+
         {isError && (
-          <SectionMessage type="error">
-            {'There was an error deleting your map.'}
-          </SectionMessage>
+          <Flex justify="center" align="center" style={{ paddingTop: 20 }}>
+            <Alert
+              type="error"
+              message="There was an error deleting your map."
+            />
+          </Flex>
         )}
-      </ModalFooter>
+      </Flex>
     </Modal>
   );
 };

--- a/react/src/components/FiltersPanel/Filter.tsx
+++ b/react/src/components/FiltersPanel/Filter.tsx
@@ -1,23 +1,19 @@
 import React from 'react';
 import styles from './Filters.module.css';
-import DatePicker from 'react-datepicker';
-import { Button, Flex } from 'antd';
-import 'react-datepicker/dist/react-datepicker.css';
+import { DatePicker } from 'antd';
+import { Button, Flex, Tooltip } from 'antd';
+import type { Dayjs } from 'dayjs';
+import { QuestionCircleOutlined } from '@ant-design/icons';
 
 interface FiltersProps {
   selectedAssetTypes: string[];
   onFiltersChange: (selectedAssetTypes: string[]) => void;
-  startDate: Date;
-  setStartDate: (date: Date) => void;
-  endDate: Date;
-  setEndDate: (date: Date) => void;
+  startDate: Dayjs;
+  setStartDate: (date: Dayjs) => void;
+  endDate: Dayjs;
+  setEndDate: (date: Dayjs) => void;
   toggleDateFilter: boolean;
   setToggleDateFilter: (toggleDateFilter: boolean) => void;
-}
-
-interface CustomInputProps {
-  value?: string;
-  onClick?: () => void;
 }
 
 export const assetTypeOptions = {
@@ -47,29 +43,6 @@ const Filters: React.FC<FiltersProps> = ({
     }
   };
 
-  const CustomInputWithTooltip = React.forwardRef<
-    HTMLInputElement,
-    CustomInputProps
-  >(({ value, onClick }, ref) => (
-    <div className={styles.customInputContainer}>
-      <input
-        className={styles.customInput}
-        value={value}
-        onClick={onClick}
-        ref={ref}
-        readOnly
-      />
-      <span
-        className={styles.tooltip}
-        title="Choose the date(s) corresponding to when the data collection occurred in the field, not when the data was uploaded to the map project."
-      >
-        ?
-      </span>
-    </div>
-  ));
-
-  CustomInputWithTooltip.displayName = 'CustomInputWithTooltip';
-
   return (
     <Flex vertical className={styles.root}>
       {toggleDateFilter ? (
@@ -77,26 +50,31 @@ const Filters: React.FC<FiltersProps> = ({
           <Button onClick={() => setToggleDateFilter(false)}>
             Disable Date Range Filter
           </Button>
-          <h2>Date Range</h2>
-          <h5>Start Date</h5>
-          <DatePicker
-            selected={startDate}
-            onChange={(date: Date | null) => setStartDate(date as Date)}
-            selectsStart
-            startDate={startDate}
-            endDate={endDate}
-            customInput={<CustomInputWithTooltip />}
-          />
-          <h5>End Date</h5>
-          <DatePicker
-            selected={endDate}
-            onChange={(date: Date | null) => setEndDate(date as Date)}
-            selectsEnd
-            startDate={startDate}
-            endDate={endDate}
-            minDate={startDate}
-            customInput={<CustomInputWithTooltip />}
-          />
+          <Flex vertical>
+            <h2>
+              <Flex align="center" justify="space-between">
+                Date Range
+                <Tooltip
+                  title="Choose the date(s) corresponding to when the data collection occurred in the field, not when the data was uploaded to the map project."
+                  placement="right"
+                >
+                  <Button type="link" icon={<QuestionCircleOutlined />} />
+                </Tooltip>
+              </Flex>
+            </h2>
+            <h5>Start Date</h5>
+            <DatePicker
+              defaultValue={startDate}
+              onChange={setStartDate}
+              allowClear={false}
+            />
+            <h5>End Date</h5>
+            <DatePicker
+              defaultValue={endDate}
+              onChange={setEndDate}
+              allowClear={false}
+            />
+          </Flex>
         </>
       ) : (
         <Button type="primary" onClick={() => setToggleDateFilter(true)}>

--- a/react/src/components/ManageMapProjectPanel/PublicTabContent.tsx
+++ b/react/src/components/ManageMapProjectPanel/PublicTabContent.tsx
@@ -20,10 +20,10 @@ const PublicTabContent: React.FC<PublicTabProps> = ({
   };
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const publicPath = window.location.href.replace(
+  const publicPath = `${window.location.origin}${window.location.pathname.replace(
     '/project/',
     '/project-public/'
-  );
+  )}`;
 
   const { Paragraph } = Typography;
   return (
@@ -47,7 +47,11 @@ const PublicTabContent: React.FC<PublicTabProps> = ({
             >
               <Button
                 type="link"
-                style={{ textWrap: 'wrap', textAlign: 'justify' }}
+                style={{
+                  textWrap: 'wrap',
+                  textAlign: 'justify',
+                  display: 'contents',
+                }}
                 href={`${publicPath}`}
                 target="_blank"
                 rel="noreferrer"

--- a/react/src/components/QuestionnaireModal/QuestionnaireModal.module.css
+++ b/react/src/components/QuestionnaireModal/QuestionnaireModal.module.css
@@ -2,6 +2,10 @@
 
 /* Target all questionnaire content injected by jQuery */
 
+.questionnaireViewContainer {
+  overflow: auto;
+}
+
 .questionnaireViewContainer :global(.view-only-questionnaire-container) {
   cursor: default;
   line-height: normal;

--- a/react/src/components/QuestionnaireModal/QuestionnaireModal.tsx
+++ b/react/src/components/QuestionnaireModal/QuestionnaireModal.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { Modal, ModalHeader, ModalBody } from 'reactstrap';
-import { LoadingSpinner, SectionMessage } from '@tacc/core-components';
+import { Modal, Layout, Flex, Alert } from 'antd';
 import { Feature } from '../../types';
 import {
   useFeatureAssetSource,
@@ -30,6 +29,8 @@ const QuestionnaireModal = ({
     error,
   } = useFeatureAssetSource(feature, '/questionnaire.rq');
   const getFeatureAssetSourcePath = useFeatureAssetSourcePath(feature);
+  const { Header } = Layout;
+
   useEffect(() => {
     const loadQuestionnaire = async () => {
       try {
@@ -56,28 +57,41 @@ const QuestionnaireModal = ({
   }, [isOpen, featureSource, getFeatureAssetSourcePath]);
 
   return (
-    <Modal isOpen={isOpen} toggle={close} size="lg">
-      <ModalHeader toggle={close}>
-        Questionnaire:{' '}
-        {feature?.assets?.length > 0
-          ? feature.assets.map((asset) =>
-              asset.display_path
-                ? asset.display_path.split('/').pop()
-                : (asset.id ?? feature.id)
-            )
-          : feature?.id}
-      </ModalHeader>
-      <ModalBody>
-        <div className={styles.questionnaireViewContainer}>
-          <div id="questionnaire-view" ref={questionnaireRef} />
-        </div>
-        {isLoading && <LoadingSpinner />}
-        {isError && (
-          <SectionMessage type="error">
-            Error loading questionnaire: {error.message}
-          </SectionMessage>
+    <Modal
+      open={isOpen}
+      onCancel={close}
+      loading={isLoading}
+      width={800}
+      footer={null}
+      title={
+        <Header style={{ height: 'fit-content' }}>
+          Questionnaire:
+          {feature?.assets?.length > 0
+            ? feature.assets.map((asset) =>
+                asset.display_path
+                  ? asset.display_path.split('/').pop()
+                  : (asset.id ?? feature.id)
+              )
+            : feature?.id}
+        </Header>
+      }
+    >
+      <Flex vertical flex={1} style={{ minHeight: '20vh', maxHeight: '70vh' }}>
+        {!isError ? (
+          <div className={styles.questionnaireViewContainer}>
+            <div id="questionnaire-view" ref={questionnaireRef} />
+          </div>
+        ) : (
+          isError && (
+            <Flex justify="center" align="center" flex={1}>
+              <Alert
+                type="error"
+                message={`Error loading questionnaire: ${error.message}`}
+              />
+            </Flex>
+          )
         )}
-      </ModalBody>
+      </Flex>
     </Modal>
   );
 };

--- a/react/src/hooks/features/useFeatures.ts
+++ b/react/src/hooks/features/useFeatures.ts
@@ -5,13 +5,14 @@ import {
 } from '@tanstack/react-query';
 import { FeatureCollection } from '@hazmapper/types';
 import { useGet } from '@hazmapper/requests';
+import type { Dayjs } from 'dayjs';
 
 interface UseFeaturesParams {
   projectId: number;
   isPublicView: boolean;
   assetTypes: string[];
-  startDate?: Date;
-  endDate?: Date;
+  startDate?: Dayjs;
+  endDate?: Dayjs;
   toggleDateFilter?: boolean;
   options?: object;
 }
@@ -29,12 +30,21 @@ export const useFeatures = ({
 }: UseFeaturesParams): UseQueryResult<FeatureCollection> => {
   // TODO can be reworked as /projects can be used and /public-projects can be removed since we are no longer a WSO2 API
   const featuresRoute = isPublicView ? 'public-projects' : 'projects';
-  let endpoint = `/${featuresRoute}/${projectId}/features/`;
+  const endpoint = `/${featuresRoute}/${projectId}/features/`;
+
+  let queryParams = {};
   if (assetTypes?.length) {
-    endpoint += `?assetType=${assetTypes.join(',')}`;
+    queryParams = {
+      ...queryParams,
+      assetType: assetTypes.join(','),
+    };
   }
   if (startDate && endDate && toggleDateFilter) {
-    endpoint += `&startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}`;
+    queryParams = {
+      ...queryParams,
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString(),
+    };
   }
 
   const defaultQueryOptions = {
@@ -54,12 +64,11 @@ export const useFeatures = ({
         projectId,
         isPublicView,
         assetTypes,
-        startDate,
-        endDate,
-        toggleDateFilter,
+        queryParams,
       },
     ],
     options: { ...defaultQueryOptions, ...options },
+    params: queryParams,
   });
   return query;
 };

--- a/react/src/pages/Callback/Callback.test.tsx
+++ b/react/src/pages/Callback/Callback.test.tsx
@@ -3,7 +3,7 @@ import { renderInTest } from '@hazmapper/test/testUtil';
 import Callback from './Callback';
 
 test('renders callback', async () => {
-  const { getByText } = renderInTest(<Callback />, '/callback');
+  const { getByTestId } = renderInTest(<Callback />, '/callback');
 
-  expect(getByText(/Logging in/)).toBeDefined();
+  expect(getByTestId('spin')).toBeTruthy();
 });

--- a/react/src/pages/Callback/Callback.tsx
+++ b/react/src/pages/Callback/Callback.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { jwtDecode } from 'jwt-decode';
 import { loginSuccess } from '../../redux/authSlice';
+import { Flex, Spin } from 'antd';
 import { AuthenticatedUser, AuthToken } from '@hazmapper/types';
 
 export default function CallbackPage() {
@@ -29,5 +30,9 @@ export default function CallbackPage() {
     }
   }, [dispatch, location, navigate]);
 
-  return <div>Logging in.</div>;
+  return (
+    <Flex justify="center" align="center" style={{ height: '100vh' }}>
+      <Spin size="large" data-testid="spin" />
+    </Flex>
+  );
 }

--- a/react/src/pages/MapProject/MapProject.module.css
+++ b/react/src/pages/MapProject/MapProject.module.css
@@ -36,7 +36,7 @@
   padding: 5px;
   right: 10px;
   top: 75px;
-  bottom: 20px;
+  bottom: 125px;
   z-index: 1050;
 }
 

--- a/react/src/pages/MapProject/MapProject.tsx
+++ b/react/src/pages/MapProject/MapProject.tsx
@@ -38,6 +38,7 @@ import * as z from 'zod';
 import { useForm, FormProvider } from 'react-hook-form';
 import StreetviewPanel from '@hazmapper/components/StreetviewPanel';
 import PublicInfoPanel from '@hazmapper/components/PublicInfoPanel';
+import dayjs from 'dayjs';
 
 export const tileLayerSchema = z.object({
   id: z.number(),
@@ -161,10 +162,9 @@ const LoadedMapProject: React.FC<LoadedMapProject> = ({
     Object.keys(assetTypeOptions)
   );
   const [toggleDateFilter, setToggleDateFilter] = React.useState(false);
-  const [startDate, setStartDate] = useState(new Date());
-  const [endDate, setEndDate] = useState(
-    new Date(Date.now() + 24 * 60 * 60 * 1000)
-  );
+  const [startDate, setStartDate] = useState(dayjs().startOf('day'));
+  const [endDate, setEndDate] = useState(dayjs().add(1, 'day').startOf('day'));
+
   const { selectedFeature, setSelectedFeatureId: toggleSelectedFeature } =
     useFeatureSelection();
   const [isQuestionnaireModalOpen, setQuestionnaireModalOpen] = useState(false);

--- a/react/src/pages/MapProject/MapProject.tsx
+++ b/react/src/pages/MapProject/MapProject.tsx
@@ -186,15 +186,14 @@ const LoadedMapProject: React.FC<LoadedMapProject> = ({
     formatAssetTypeName(type)
   );
 
-  const { data: rawFeatureCollection, isLoading: isFeaturesLoading } =
-    useFeatures({
-      projectId: activeProject.id,
-      isPublicView,
-      assetTypes: formattedAssetTypes,
-      startDate,
-      endDate,
-      toggleDateFilter,
-    });
+  const { data: rawFeatureCollection } = useFeatures({
+    projectId: activeProject.id,
+    isPublicView,
+    assetTypes: formattedAssetTypes,
+    startDate,
+    endDate,
+    toggleDateFilter,
+  });
 
   const { data: tileServerLayers, isLoading: isTileServerLayersLoading } =
     useGetTileServers({
@@ -206,8 +205,6 @@ const LoadedMapProject: React.FC<LoadedMapProject> = ({
 
   const queryParams = new URLSearchParams(location.search);
   const activePanel = queryParams.get(queryPanelKey);
-
-  const loading = isFeaturesLoading || isTileServerLayersLoading;
 
   const featureCollection = rawFeatureCollection ?? {
     type: 'FeatureCollection',
@@ -263,7 +260,7 @@ const LoadedMapProject: React.FC<LoadedMapProject> = ({
                 }}
               >
                 <MapProjectNavBar isPublicView={isPublicView} />
-                {activePanel && !loading && (
+                {activePanel && !isTileServerLayersLoading && (
                   <BasePanel
                     panelTitle={activePanel}
                     className={
@@ -315,33 +312,31 @@ const LoadedMapProject: React.FC<LoadedMapProject> = ({
               </Flex>
             </Sider>
             <Content>
-              {loading ? (
+              {isTileServerLayersLoading ? (
                 <Spinner />
               ) : (
                 <>
                   <div className={styles.map}>
                     <Map featureCollection={featureCollection} />
                   </div>
-                  {selectedFeature && (
-                    <div className={styles.detailContainer}>
-                      <AssetDetail
-                        selectedFeature={selectedFeature}
-                        onClose={() =>
-                          toggleSelectedFeature(selectedFeature.id)
-                        }
-                        isPublicView={isPublicView}
-                        onQuestionnaireClick={handleQuestionnaireClick}
-                      />
-                    </div>
-                  )}
-                  {isQuestionnaireModalOpen && selectedFeature && (
-                    <QuestionnaireModal
-                      isOpen={isQuestionnaireModalOpen}
-                      close={() => setQuestionnaireModalOpen(false)}
-                      feature={selectedFeature}
-                    />
-                  )}
                 </>
+              )}
+              {selectedFeature && (
+                <div className={styles.detailContainer}>
+                  <AssetDetail
+                    selectedFeature={selectedFeature}
+                    onClose={() => toggleSelectedFeature(selectedFeature.id)}
+                    isPublicView={isPublicView}
+                    onQuestionnaireClick={handleQuestionnaireClick}
+                  />
+                </div>
+              )}
+              {isQuestionnaireModalOpen && selectedFeature && (
+                <QuestionnaireModal
+                  isOpen={isQuestionnaireModalOpen}
+                  close={() => setQuestionnaireModalOpen(false)}
+                  feature={selectedFeature}
+                />
               )}
             </Content>
           </Layout>

--- a/react/src/requests.ts
+++ b/react/src/requests.ts
@@ -113,7 +113,7 @@ export function useGet<ResponseType, TransformedResponseType = ResponseType>({
       }
       analytics_params = { ...analytics_params, guest_uuid: guestUuid };
     }
-    params = { ...analytics_params };
+    params = { ...params, ...analytics_params };
   }
 
   const getUtil = async () => {


### PR DESCRIPTION
## Overview: ##

Various UI/UX fixes from the Feb 18 testing session.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-441](https://tacc-main.atlassian.net/browse/WG-441)
* [WG-457](https://tacc-main.atlassian.net/browse/WG-457)
* [WG-445](https://tacc-main.atlassian.net/browse/WG-445)
* [WG-443](https://tacc-main.atlassian.net/browse/WG-443)

## Summary of Changes: ##

- add loading spinner on login callback layout
- public project links now stay within container when long
- public project links now link directly to the project, with no panel selected
- delete map modal and questionnaire modal refactored to antd; close button fixed.
- refactor datepicker to antd; add visually clear tooltip
- fix re-render issue on filter change
- add bottom margin to asset detail in order to show leaflet zoom buttons

## Testing Steps: ##
1. Test each of the above and ensure they work as expected

## UI Photos:

![Screenshot 2025-02-19 at 1 01 31 PM](https://github.com/user-attachments/assets/ba3a79a0-8ff9-42be-8c7a-48dd3710453c)
![Screenshot 2025-02-19 at 1 33 31 PM](https://github.com/user-attachments/assets/593e9118-31b9-4524-8afb-2072fc789951)
![Screenshot 2025-02-19 at 1 33 43 PM](https://github.com/user-attachments/assets/6012b51b-f5c7-486a-a0b7-fa128a40efc6)
![Screenshot 2025-02-19 at 5 19 37 PM](https://github.com/user-attachments/assets/f2798428-9b4a-4e3d-a841-882a1e60dec2)
![Screenshot 2025-02-19 at 5 30 26 PM](https://github.com/user-attachments/assets/b196b723-2754-4072-846e-37fc5bb264ae)

## Notes: ##

Do we like the asset panel solution to make sure the leaflet zoom buttons are visible?