### PR TITLE
bug/WG-449-Success-toast-with-error-msg

### DIFF
--- a/react/src/components/AssetDetail/AssetButton.tsx
+++ b/react/src/components/AssetDetail/AssetButton.tsx
@@ -56,7 +56,7 @@ const AssetButton: React.FC<AssetButtonProps> = ({
         },
         onError: (error) => {
           setIsModalOpen(false);
-          notification.success({
+          notification.error({
             description: `There was an error importing your asset for feature ${selectedFeature.id}. Error: ${error}`,
           });
         },

--- a/react/src/utils/fileUtils.ts
+++ b/react/src/utils/fileUtils.ts
@@ -14,7 +14,6 @@ export const IMPORTABLE_FEATURE_TYPES = [
 export const IMPORTABLE_FEATURE_ASSET_TYPES = [
   'jpeg',
   'jpg',
-  'png',
   'mp4',
   'mov',
   'mpeg4',


### PR DESCRIPTION
## Overview: ##
Bug - success toast with error message when importing an asset to a feature with no asset
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-449](https://tacc-main.atlassian.net/browse/WG-449)

## Summary of Changes: ##
- Fixed notification.success for onError state
- Angular/ Hazmapper prod allowed pngs assets to features but didn't actually work and import failed. 
    - Removed this because geoapi doesn't allow png imports. See createFeatureAsset in [geoapi/services/features.py](https://github.com/TACC-Cloud/geoapi/blob/b67ba873baf7e35ce5279fc0dbc03ce79769ede4/geoapi/services/features.py#L528). Geoapi will always return "Invalid format for feature assets" error message. Was png imports on prod ever working? Was this intended to work?

## Testing Steps: ##
1. On your own map, create a feature with no asset. Try importing geojson data from GEOAPI Test do not edit project
2. Try importing a png file. Go to published data in file browser -> select PRJ - 1972 -> select San_Jac2.png and make sure that import is disabled. 
3. Check that png is no longer listed in the Allowed file types at the top of the modal
4. Check code to see where there was a copy + paste error that told notification to show success style notification when error
5. If you want to check what the error notification will look like, add png back to the Importable_feature_asset_types in fileUtils and try and import the same San_Jac2.png.


## UI Photos:

## Notes: ##
