### PR TITLE
Hotfix/avoid queries when not logged

### DIFF
--- a/react/src/components/CreateMapModal/CreateMapModal.test.tsx
+++ b/react/src/components/CreateMapModal/CreateMapModal.test.tsx
@@ -16,8 +16,8 @@ jest.mock('@hazmapper/hooks/user/useAuthenticatedUser', () => ({
   __esModule: true,
   default: () => ({
     data: { username: 'mockUser' },
-    isLoading: false,
-    error: null,
+    username: 'mockUser',
+    hasValidTapisToken: true,
   }),
 }));
 

--- a/react/src/components/HeaderNavBar/HeaderNavBar.test.tsx
+++ b/react/src/components/HeaderNavBar/HeaderNavBar.test.tsx
@@ -15,9 +15,8 @@ jest.mock('react-router-dom', () => ({
 }));
 
 const mockAuthenticatedUser = {
-  data: null,
-  isLoading: false,
-  error: null,
+  username: '',
+  hasValidTapisToken: false,
 };
 
 jest.mock('@hazmapper/hooks/user/useAuthenticatedUser', () => {
@@ -32,7 +31,7 @@ jest.mock('@hazmapper/hooks/user/useAuthenticatedUser', () => {
 describe('HeaderNavBar', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
-    mockAuthenticatedUser.data = null;
+    mockAuthenticatedUser.username = '';
   });
 
   test('clicking login button should navigate to login with correct return URL', () => {
@@ -62,7 +61,7 @@ describe('HeaderNavBar', () => {
 
   test('displays username when user is authenticated', () => {
     Object.assign(mockAuthenticatedUser, {
-      data: { username: 'testUser' },
+      username: 'testUser',
     });
 
     const { getByText, queryByText } = renderInTest(<HeaderNavBar />);

--- a/react/src/components/HeaderNavBar/HeaderNavBar.tsx
+++ b/react/src/components/HeaderNavBar/HeaderNavBar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import useAuthenticatedUser from '@hazmapper/hooks/user/useAuthenticatedUser';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { Button, InlineMessage, LoadingSpinner } from '@tacc/core-components';
+import { Button } from '@tacc/core-components';
 import hazmapperHeaderLogo from '@hazmapper/assets/hazmapper-header-logo.png';
 import styles from './HeaderNavBar.module.css';
 import * as ROUTES from '@hazmapper/constants/routes';
@@ -10,11 +10,7 @@ export const HeaderNavBar: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const {
-    data: userData,
-    isLoading: isUserLoading,
-    error: isUserError,
-  } = useAuthenticatedUser();
+  const { username } = useAuthenticatedUser();
 
   const handleLogin = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -22,19 +18,6 @@ export const HeaderNavBar: React.FC = () => {
     const url = `${ROUTES.LOGIN}?to=${encodeURIComponent(location.pathname)}`;
     navigate(url);
   };
-
-  if (isUserLoading) {
-    return <LoadingSpinner />;
-  }
-
-  if (isUserError) {
-    return (
-      <InlineMessage type="error">
-        {' '}
-        There was an error loading your username.
-      </InlineMessage>
-    );
-  }
 
   return (
     <div
@@ -46,8 +29,8 @@ export const HeaderNavBar: React.FC = () => {
       tabIndex={0}
     >
       <img width="150px" src={hazmapperHeaderLogo} alt="Hazmapper Logo" />
-      {userData?.username ? (
-        <div className={styles.userName}>{userData.username}</div>
+      {username ? (
+        <div className={styles.userName}>{username}</div>
       ) : (
         <Button type="link" className={styles.userName} onClick={handleLogin}>
           Login

--- a/react/src/components/MapControlBar/MapControlbar.tsx
+++ b/react/src/components/MapControlBar/MapControlbar.tsx
@@ -53,7 +53,7 @@ interface Props {
  */
 const MapControlbar: React.FC<Props> = ({ activeProject, isPublicView }) => {
   const navigate = useNavigate();
-  const { data: authenticatedUser } = useAuthenticatedUser();
+  const { username, hasValidTapisToken } = useAuthenticatedUser();
 
   const { data: activeProjectUsers } = useProjectUsers({
     projectId: activeProject?.id ?? -1, // Provide a dummy fallback value
@@ -61,7 +61,7 @@ const MapControlbar: React.FC<Props> = ({ activeProject, isPublicView }) => {
       // Only fetch users when viewing a public map, user is authenticated, and
       // there is an active project - this determines if we need to check list of users
       // to see if current user can switch to private view
-      enabled: Boolean(isPublicView && authenticatedUser && activeProject?.id),
+      enabled: Boolean(isPublicView && hasValidTapisToken && activeProject?.id),
     },
   });
 
@@ -74,8 +74,8 @@ const MapControlbar: React.FC<Props> = ({ activeProject, isPublicView }) => {
   const { data: designSafeProject } = useDesignSafeProject({
     designSafeProjectUUID: designSafeProjectUUID,
     options: {
-      // Only fetch users when user is authenticated
-      enabled: Boolean(authenticatedUser && designSafeProjectUUID),
+      // Only fetch DS project when there is an associated one and when user is authenticated
+      enabled: Boolean(hasValidTapisToken && designSafeProjectUUID),
     },
   });
 
@@ -87,8 +87,8 @@ const MapControlbar: React.FC<Props> = ({ activeProject, isPublicView }) => {
   /* for public maps, check if user is logged in and in the activeProjectUsers list */
   const canSwitchToPrivateMap =
     isPublicView &&
-    authenticatedUser &&
-    activeProjectUsers?.find((u) => u.username === authenticatedUser.username)
+    hasValidTapisToken &&
+    activeProjectUsers?.find((u) => u.username === username)
       ? true
       : false;
 

--- a/react/src/hooks/features/useDeleteFeature.ts
+++ b/react/src/hooks/features/useDeleteFeature.ts
@@ -29,7 +29,6 @@ export function useDeleteFeature() {
         );
         queryClient.invalidateQueries({
           queryKey: [KEY_USE_FEATURES],
-          meta: { reason: 'deletion' },
         });
 
         // Update Zustand store

--- a/react/src/hooks/notifications/useGeoapiNotificationsPolling.ts
+++ b/react/src/hooks/notifications/useGeoapiNotificationsPolling.ts
@@ -6,6 +6,7 @@ import {
   KEY_USE_FEATURES,
   KEY_USE_POINT_CLOUDS,
   KEY_USE_TILE_SERVERS,
+  useAuthenticatedUser,
 } from '@hazmapper/hooks';
 import { useNotification } from './useNotification';
 
@@ -14,6 +15,7 @@ const POLLING_INTERVAL = 5000; // 5 seconds
 export const useGeoapiNotificationsPolling = () => {
   const queryClient = useQueryClient();
   const notification = useNotification();
+  const { hasValidTapisToken } = useAuthenticatedUser();
 
   const getStartDate = () => {
     // Get the current timestamp minus the polling interval
@@ -32,6 +34,7 @@ export const useGeoapiNotificationsPolling = () => {
       refetchInterval: POLLING_INTERVAL,
       refetchIntervalInBackground: true,
       retry: 3,
+      enabled: hasValidTapisToken,
     },
   });
 

--- a/react/src/hooks/systems/useSystems.ts
+++ b/react/src/hooks/systems/useSystems.ts
@@ -15,16 +15,18 @@ export type TransformedGetSystemsResponse = {
 };
 
 type propsType = {
-  suspense?: boolean;
   prefetch?: boolean;
+  enabled?: boolean;
 };
 
 const defaultProps: propsType = {
   prefetch: false,
+  enabled: true,
 };
 
 export const useGetSystems = ({
   prefetch,
+  enabled,
 }: propsType = defaultProps): UseQueryResult<TransformedGetSystemsResponse> => {
   const queryResult = useGet<
     TUseGetSystemsResponse,
@@ -35,6 +37,7 @@ export const useGetSystems = ({
     apiService: ApiService.Tapis,
     prefetch,
     options: {
+      enabled,
       refetchOnMount: false,
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,

--- a/react/src/hooks/user/useAuthenticatedUser.ts
+++ b/react/src/hooks/user/useAuthenticatedUser.ts
@@ -1,22 +1,39 @@
 import { useSelector } from 'react-redux';
 import { RootState } from '../../redux/store';
 import { AuthenticatedUser } from '@hazmapper/types';
+import { isTokenValid } from '@hazmapper/utils/authUtils';
 
-type SuccessResult<T> = {
-  data: T;
-  isLoading: false;
-  error: null;
-};
+/**
+ * A hook that returns authentication-related user information
+ *
+ * This hook performs no side effects (e.g., no navigation or redirect).
+ * For side-effect-driven authentication, use `useEnsureAuthenticatedUserHasValidTapisToken` instead.
+ *
+ * @returns An object containing:
+ *  - `data`: an object with the user's username (to be removed; TODO),
+ *  - `username`: the authenticated user's username (empty string if unauthenticated),
+ *  - `hasValidTapisToken`: a boolean indicating whether the stored auth token is valid.
+ */
 
-// TODO remove this placeholder hook
-const useAuthenticatedUser = (): SuccessResult<AuthenticatedUser> => {
+const useAuthenticatedUser = (): {
+  data: AuthenticatedUser;
+  username: string;
+  hasValidTapisToken: boolean;
+} => {
   let username = useSelector((state: RootState) => state.auth.user?.username);
 
   if (!username) {
     username = '';
   }
 
-  return { data: { username }, isLoading: false, error: null };
+  const authToken = useSelector((state: RootState) => state.auth.authToken);
+  const hasValidTapisToken = !!authToken && isTokenValid(authToken);
+
+  return {
+    data: { username } /* TODO remove and use username */,
+    username,
+    hasValidTapisToken,
+  };
 };
 
 export default useAuthenticatedUser;

--- a/react/src/hooks/user/useEnsureAuthenticatedUserHasValidTapisToken.ts
+++ b/react/src/hooks/user/useEnsureAuthenticatedUserHasValidTapisToken.ts
@@ -3,6 +3,19 @@ import { useSelector } from 'react-redux';
 import { isTokenValid } from '@hazmapper/utils/authUtils';
 import { RootState } from '../../redux/store';
 
+/**
+ * useEnsureAuthenticatedUserHasValidTapisToken
+ *
+ * A hook that ensures the current authenticated user has a valid Tapis auth token.
+ * If the token is invalid, the user is automatically redirected to the login page.
+ *
+ * Useful for protecting private routes or pages that require an authenticated session.
+ *
+ * See `hasValidTapisToken from `useAuthenticatedUser` if you want similar functionality
+ * without the redirection
+ *
+ * @returns {void}
+ */
 export function useEnsureAuthenticatedUserHasValidTapisToken() {
   const navigate = useNavigate();
   const location = useLocation();

--- a/react/src/pages/MainMenu/MainMenu.test.tsx
+++ b/react/src/pages/MainMenu/MainMenu.test.tsx
@@ -6,9 +6,8 @@ import { renderInTest } from '@hazmapper/test/testUtil';
 jest.mock('@hazmapper/hooks/user/useAuthenticatedUser', () => ({
   __esModule: true,
   default: () => ({
-    data: { username: 'mockUser' },
-    isLoading: false,
-    error: null,
+    username: 'mockUser',
+    hasValidTapisToken: true,
   }),
 }));
 

--- a/react/src/pages/MapProject/MapProject.test.tsx
+++ b/react/src/pages/MapProject/MapProject.test.tsx
@@ -27,8 +27,8 @@ jest.mock('@hazmapper/hooks/user/useAuthenticatedUser', () => ({
   __esModule: true,
   default: () => ({
     data: { username: 'mockUser' },
-    isLoading: false,
-    error: null,
+    username: 'mockUser',
+    hasValidTapisToken: true,
   }),
 }));
 
@@ -94,8 +94,8 @@ describe('MapProject', () => {
   test('shows login prompt for 403 error when not logged in', async () => {
     jest.spyOn(UserHooks, 'default').mockImplementation(() => ({
       data: { username: '' },
-      isLoading: false,
-      error: null,
+      username: '',
+      hasValidTapisToken: false,
     }));
 
     server.use(

--- a/react/src/pages/MapProject/MapProject.tsx
+++ b/react/src/pages/MapProject/MapProject.tsx
@@ -68,7 +68,11 @@ interface MapProjectProps {
 const MapProject: React.FC<MapProjectProps> = ({ isPublicView = false }) => {
   const { projectUUID } = useParams();
 
-  useGetSystems({ prefetch: true });
+  /* prefetch systems for non-public projects (for public projects,
+   *  user might not be authed so can't get systems) as file manager
+   * will need it
+   */
+  useGetSystems({ prefetch: !isPublicView, enabled: !isPublicView });
 
   /*TODO: notifications are user specific and lacking additional context.  See note in react/src/types/notification.ts and WG-431 */
 


### PR DESCRIPTION
## Overview: ##

Rework some queries so they are disabled when the user isn't logged in or for other reasons. Specifically
* fixes prefetching of systems (i.e. useSystems) so that we only do it for logged-in users 
* fixes fetching of notifications (i.e. useGeoapiNotificationsPolling) so we only do it for logged-in users
* fixes fetching of project user (i.e. useProjectUsers)  for logged-in users

This PR also Adds `hasValidTapisToken` to useAuthenticatedUser and improves docstr for:
* useAuthenticatedUser
* useEnsureAuthenticatedUserHasValidTapisToken

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

None

## Testing Steps: ##
1. Go to public map in incognito mode so you aren't logged in.
2. Confirm there are no failed requests. You can filter requests in network tab to show request with `projects`. You should just see the expected requests for features, layers etc.
