### PR TITLE
Hotfix/length calculation and point lat lon

### DIFF
--- a/react/src/__fixtures__/featuresFixture.ts
+++ b/react/src/__fixtures__/featuresFixture.ts
@@ -265,6 +265,47 @@ export const mockPointFeature: Feature = {
   assets: [],
 };
 
+/* outline of ROC building */
+export const mockPolygonFeature: Feature = {
+  id: 100002,
+  project_id: 100,
+  type: 'Feature',
+  properties: {},
+  geometry: {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [-97.72615552541615, 30.39020755823151],
+        [-97.72497754777392, 30.389828528170284],
+        [-97.7248597435117, 30.390092736470493],
+        [-97.72501920782376, 30.39014983950544],
+        [-97.724983480877, 30.3902375228444],
+        [-97.72599137078491, 30.39056060620544],
+        [-97.72615552541615, 30.39020755823151],
+      ],
+    ],
+  },
+  styles: null,
+  assets: [],
+};
+
+/* line along south side of ROC building */
+export const mockLineFeature: Feature = {
+  id: 100003,
+  project_id: 100,
+  type: 'Feature',
+  properties: {},
+  geometry: {
+    coordinates: [
+      [-97.7261476238652, 30.390195588919497],
+      [-97.72496908641067, 30.38982235634731],
+    ],
+    type: 'LineString',
+  },
+  styles: null,
+  assets: [],
+};
+
 export const mockVideoFeature: Feature = {
   id: 100002,
   project_id: 100,

--- a/react/src/components/AssetDetail/AssetGeometry.test.tsx
+++ b/react/src/components/AssetDetail/AssetGeometry.test.tsx
@@ -34,7 +34,6 @@ describe('AssetGeometry', () => {
     );
     expect(getByText('Geometry: Line String')).toBeDefined();
     expect(getByText('Length (m)')).toBeDefined();
-    // Check that the length value is displayed correctly
     expect(getByText('Length (m)').nextElementSibling?.textContent).toBe(
       '120.42'
     );
@@ -47,7 +46,6 @@ describe('AssetGeometry', () => {
     );
     expect(getByText('Geometry: Polygon')).toBeDefined();
     expect(getByText('Area (m²)')).toBeDefined();
-    // Check that the area value is displayed correctly
     expect(getByText('Area (m²)').nextElementSibling?.textContent).toBe(
       '4917.50'
     );

--- a/react/src/components/AssetDetail/AssetGeometry.test.tsx
+++ b/react/src/components/AssetDetail/AssetGeometry.test.tsx
@@ -1,28 +1,56 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import AssetGeometry from './AssetGeometry';
-import { mockImgFeature } from '@hazmapper/__fixtures__/featuresFixture';
-
-jest.mock('@turf/turf', () => ({
-  ...jest.requireActual('@turf/turf'),
-  area: jest.fn(() => 1234.56),
-  length: jest.fn(() => 5678.9),
-  bbox: jest.fn(() => [10, 20, 30, 40]),
-}));
+import {
+  mockImgFeature,
+  mockLineFeature,
+  mockPolygonFeature,
+} from '@hazmapper/__fixtures__/featuresFixture';
 
 jest.mock('@hazmapper/hooks', () => ({
   useFeatureSelection: jest.fn(),
 }));
 
 describe('AssetGeometry', () => {
-  const GeometryAssetProps = {
-    selectedFeature: mockImgFeature,
-  };
-
   it('renders geometry for point on an image', () => {
-    const { getByText } = render(<AssetGeometry {...GeometryAssetProps} />);
+    const { getByText, queryByText } = render(
+      <AssetGeometry selectedFeature={mockImgFeature} />
+    );
     expect(getByText('Geometry: Point')).toBeDefined();
     expect(getByText('Latitude')).toBeDefined();
+    expect(getByText('Latitude').nextElementSibling?.textContent).toBe(
+      '30.389785554'
+    );
     expect(getByText('Longitude')).toBeDefined();
+    expect(getByText('Longitude').nextElementSibling?.textContent).toBe(
+      '-97.726075437'
+    );
+    expect(queryByText('Bounding Box')).toBeNull();
+  });
+
+  it('renders line feature with length', () => {
+    const { getByText } = render(
+      <AssetGeometry selectedFeature={mockLineFeature} />
+    );
+    expect(getByText('Geometry: Line String')).toBeDefined();
+    expect(getByText('Length (m)')).toBeDefined();
+    // Check that the length value is displayed correctly
+    expect(getByText('Length (m)').nextElementSibling?.textContent).toBe(
+      '120.42'
+    );
+    expect(getByText('Bounding Box')).toBeDefined();
+  });
+
+  it('renders polygon feature with area', () => {
+    const { getByText } = render(
+      <AssetGeometry selectedFeature={mockPolygonFeature} />
+    );
+    expect(getByText('Geometry: Polygon')).toBeDefined();
+    expect(getByText('Area (m²)')).toBeDefined();
+    // Check that the area value is displayed correctly
+    expect(getByText('Area (m²)').nextElementSibling?.textContent).toBe(
+      '4917.50'
+    );
+    expect(getByText('Bounding Box')).toBeDefined();
   });
 });

--- a/react/src/components/AssetDetail/AssetGeometry.tsx
+++ b/react/src/components/AssetDetail/AssetGeometry.tsx
@@ -12,10 +12,7 @@ interface AssetGeometryProps {
 const AssetGeometry: React.FC<AssetGeometryProps> = ({ selectedFeature }) => {
   if (!selectedFeature?.geometry) return null;
 
-  const bbox =
-    selectedFeature.geometry.type !== 'Point'
-      ? turf.bbox(selectedFeature as TFeature)
-      : null;
+  const bbox = turf.bbox(selectedFeature.geometry);
 
   const geometryType = selectedFeature.geometry.type;
 
@@ -33,11 +30,11 @@ const AssetGeometry: React.FC<AssetGeometryProps> = ({ selectedFeature }) => {
           <tbody>
             <tr>
               <td>Latitude</td>
-              <td>{turf.bbox(selectedFeature.geometry)[0]}</td>
+              <td>{bbox[1]}</td>
             </tr>
             <tr>
               <td>Longitude</td>
-              <td>{turf.bbox(selectedFeature.geometry)[1]}</td>
+              <td>{bbox[0]}</td>
             </tr>
           </tbody>
         </table>
@@ -73,12 +70,17 @@ const AssetGeometry: React.FC<AssetGeometryProps> = ({ selectedFeature }) => {
           <tbody>
             <tr>
               <td>Length (m)</td>
-              <td>{turf.length(selectedFeature as TFeature).toFixed(2)}</td>
+              <td>
+                {turf
+                  .length(selectedFeature as TFeature, { units: 'meters' })
+                  .toFixed(2)}
+              </td>
             </tr>
           </tbody>
         </table>
       )}
-      {geometryType !== FeatureType.Point && bbox && (
+      {/* Bounding box for non-point geometries */}
+      {geometryType !== FeatureType.Point && (
         <table>
           <thead>
             {selectedFeature.geometry.type === 'GeometryCollection' && (
@@ -102,13 +104,13 @@ const AssetGeometry: React.FC<AssetGeometryProps> = ({ selectedFeature }) => {
             </tr>
             <tr>
               <td>Minimum</td>
-              <td>{turf.bbox(selectedFeature.geometry)[1]}</td>
-              <td>{turf.bbox(selectedFeature.geometry)[0]}</td>
+              <td>{bbox[1]}</td>
+              <td>{bbox[0]}</td>
             </tr>
             <tr>
               <td>Maximum</td>
-              <td>{turf.bbox(selectedFeature.geometry)[3]}</td>
-              <td>{turf.bbox(selectedFeature.geometry)[2]}</td>
+              <td>{bbox[3]}</td>
+              <td>{bbox[2]}</td>
             </tr>
           </tbody>
         </table>

--- a/react/src/hooks/features/useDeleteFeature.ts
+++ b/react/src/hooks/features/useDeleteFeature.ts
@@ -29,7 +29,6 @@ export function useDeleteFeature() {
         );
         queryClient.invalidateQueries({
           queryKey: [KEY_USE_FEATURES],
-          meta: { reason: 'deletion' },
         });
 
         // Update Zustand store


### PR DESCRIPTION
## Overview: ##

PR Fixes:

- Corrects latitude/longitude order in point display (previously swapped).
- Fixes length calculation by specifying units as meters in turf.length() (default is kilometers).
         - (Note: turf.area() correctly defaults to square meters 👍)

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

None

## Testing Steps: ##
1. Run unit tests 
2. Check different features and look at display in frontend