### PR TITLE
task/WG-473: Use loading spinner and virtual list in point cloud panel

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -41,6 +41,7 @@
         "react-resize-detector": "^7.1.2",
         "react-router-dom": "^6.28.1",
         "react-table": "^7.8.0",
+        "react-window": "^1.8.11",
         "reactstrap": "^9.2.3",
         "uuid": "^11.0.5",
         "yup": "^1.6.1",

--- a/react/package.json
+++ b/react/package.json
@@ -65,6 +65,7 @@
     "react-resize-detector": "^7.1.2",
     "react-router-dom": "^6.28.1",
     "react-table": "^7.8.0",
+    "react-window": "^1.8.11",
     "reactstrap": "^9.2.3",
     "uuid": "^11.0.5",
     "yup": "^1.6.1",

--- a/react/src/components/PointCloudsPanel/PointCloudPanelListItem.tsx
+++ b/react/src/components/PointCloudsPanel/PointCloudPanelListItem.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Button, Tooltip, Space, Flex } from 'antd';
+import { InfoCircleOutlined } from '@ant-design/icons';
+import {
+  UploadPointCloudButton,
+  DeletePointCloudButton,
+} from './PointCloudPanelButtons';
+import { PointCloud } from '@hazmapper/types';
+
+export interface PointCloudPanelListItemProps {
+  pointCloud: PointCloud;
+  onViewInfo: (pointCloud: PointCloud) => void;
+}
+
+export const PointCloudPanelListItem: React.FC<
+  PointCloudPanelListItemProps
+> = ({ pointCloud, onViewInfo }) => {
+  return (
+    <Flex vertical gap="small" style={{ width: '100%' }}>
+      <Tooltip title={pointCloud.description}>
+        <div
+          style={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {pointCloud.description}
+        </div>
+      </Tooltip>
+
+      <Space wrap>
+        <UploadPointCloudButton pointCloud={pointCloud} />
+        <DeletePointCloudButton
+          projectId={pointCloud.project_id}
+          pointCloudId={pointCloud.id}
+        />
+        <Tooltip title="View additional information">
+          <Button
+            size="small"
+            icon={<InfoCircleOutlined />}
+            onClick={() => onViewInfo(pointCloud)}
+          />
+        </Tooltip>
+      </Space>
+    </Flex>
+  );
+};


### PR DESCRIPTION
## Overview: ##

Improve point cloud panel performance for large lists:
- Add a loading spinner while fetching point clouds
- Use a virtual list for efficient rendering

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-473](https://tacc-main.atlassian.net/browse/WG-473)

## Summary of Changes: ##

- Refactored the point cloud list item into a separate component: PointCloudPanelListItem.tsx
- Added a loading spinner while fetching point clouds
- Integrated FixedSizeList from react-window for efficient list rendering

## Testing Steps: ##

in "react/src/secret_local.ts" have the following to test with staging:

```
import {
  DesignSafePortalEnvironment,
  GeoapiBackendEnvironment,
  LocalAppConfiguration,
} from '@hazmapper/types';


export const localDevelopmentConfiguration: LocalAppConfiguration = {
  geoapiBackend: GeoapiBackendEnvironment.Staging,
  designSafePortal: DesignSafePortalEnvironment.PPRD
};
```

1. add npm package so a `npm install` or `npm ci` is needed
2. Test with this staging project http://localhost:4200/project/b148ab1c-3195-49d9-81cc-da845bae59d1?panel=Point+Clouds
3. Compare with the same deployed project: https://hazmapper.tacc.utexas.edu/staging/project/b148ab1c-3195-49d9-81cc-da845bae59d1?panel=Point+Clouds


