### PR TITLE
task/WG-542: fix arcgis tile layers

### DIFF
--- a/react/src/components/Map/Map.tsx
+++ b/react/src/components/Map/Map.tsx
@@ -232,7 +232,7 @@ const LeafletMap: React.FC = () => {
           <TiledMapLayer
             key={layer.id}
             url={layer.url}
-            maxZoom={24}
+            maxZoom={MAP_CONFIG.maxZoom}
             zIndex={layer.uiOptions.zIndex}
             opacity={layer.uiOptions.opacity}
           />

--- a/react/src/components/Map/Map.tsx
+++ b/react/src/components/Map/Map.tsx
@@ -229,7 +229,13 @@ const LeafletMap: React.FC = () => {
             {...layer.tileOptions}
           />
         ) : layer.type === 'arcgis' ? (
-          <TiledMapLayer key={layer.id} url={layer.url} maxZoom={24} />
+          <TiledMapLayer
+            key={layer.id}
+            url={layer.url}
+            maxZoom={24}
+            zIndex={layer.uiOptions.zIndex}
+            opacity={layer.uiOptions.opacity}
+          />
         ) : (
           <TileLayer
             key={layer.id}


### PR DESCRIPTION
## Overview: ##

Fix arcgis tile layers so that they use opacity and zindex 

## PR Status: ##

* [X] Ready.


## Related Jira tickets: ##

* [WG-542](https://tacc-main.atlassian.net/browse/WG-542)

## Testing Steps: ##
1. Find a map with arcgis tile layers . Test changing opacity or zindex.

You could point to prod and look at a Camp Wildfire (https://hazmapper.tacc.utexas.edu/hazmapper/project-public/a1e0eb3a-8db7-4b2a-8412-80213841570b?panel=Layers&selectedFeature=560894).  So GeoapiBackendEnvironment.Production and DesignSafePortalEnvironment.Production in `react/src/secret_local.ts`)

