### PR TITLE
Fix/improve size of tile layer modal and fix ordering issues

### DIFF
--- a/react/src/components/CreateLayerModal/CreateLayerModal.tsx
+++ b/react/src/components/CreateLayerModal/CreateLayerModal.tsx
@@ -143,6 +143,8 @@ const CreateLayerModal: React.FC<{
       title={<Header>Create a Tile Layer</Header>}
       open={isOpen}
       onCancel={handleClose}
+      width="90vw"
+      style={{ maxWidth: 800 }}
       footer={[
         <Button key="closeModalButton" onClick={handleClose}>
           Cancel

--- a/react/src/components/CreateLayerModal/TileServerSuggestions.tsx
+++ b/react/src/components/CreateLayerModal/TileServerSuggestions.tsx
@@ -4,44 +4,53 @@ import { PlusOutlined } from '@ant-design/icons';
 import { TileServerLayer } from '@hazmapper/types';
 import { PrimaryButton } from '@hazmapper/common_components/Button';
 
-const DEFAULT_TILE_SERVERS: ReadonlyArray<Omit<TileServerLayer, 'id'>> = [
+const DEFAULT_TILE_SERVERS: ReadonlyArray<{
+  description: string;
+  tileServer: Omit<TileServerLayer, 'id'>;
+}> = [
   {
-    name: 'Roads',
-    type: 'tms',
-    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-    attribution:
-      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-    uiOptions: {
-      opacity: 1,
-      isActive: true,
-      showDescription: false,
-      showInput: false,
-      zIndex: 0,
-    },
-    tileOptions: {
-      minZoom: 0,
-      maxZoom: 24,
-      maxNativeZoom: 19,
+    description: 'OpenStreetMap street map with roads, buildings, and labels.',
+    tileServer: {
+      name: 'Roads',
+      type: 'tms',
+      url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      uiOptions: {
+        opacity: 1,
+        isActive: true,
+        showDescription: false,
+        showInput: false,
+        zIndex: 0,
+      },
+      tileOptions: {
+        minZoom: 0,
+        maxZoom: 24,
+        maxNativeZoom: 19,
+      },
     },
   },
   {
-    name: 'Satellite',
-    type: 'tms',
-    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
-    attribution:
-      'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, \
+    description: 'Esri world imagery with aerial and satellite photos.',
+    tileServer: {
+      name: 'Satellite',
+      type: 'tms',
+      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+      attribution:
+        'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, \
       GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
-    uiOptions: {
-      zIndex: 0,
-      opacity: 1,
-      isActive: true,
-      showDescription: false,
-      showInput: false,
-    },
-    tileOptions: {
-      minZoom: 0,
-      maxZoom: 24,
-      maxNativeZoom: 19,
+      uiOptions: {
+        zIndex: 0,
+        opacity: 1,
+        isActive: true,
+        showDescription: false,
+        showInput: false,
+      },
+      tileOptions: {
+        minZoom: 0,
+        maxZoom: 24,
+        maxNativeZoom: 19,
+      },
     },
   },
 ];
@@ -53,14 +62,19 @@ type Props = {
 const TileServerSuggestions: React.FC<Props> = ({ onImport }) => {
   return (
     <>
-      {DEFAULT_TILE_SERVERS.map((tileServer, index) => (
+      {DEFAULT_TILE_SERVERS.map(({ tileServer, description }, index) => (
         <Flex
           key={`suggestedTile${index}`}
           justify="space-between"
           align="center"
           style={{ marginBottom: '1.5rem' }}
         >
-          <span>{tileServer.name}</span>
+          <div>
+            <span style={{ fontWeight: 500 }}>{tileServer.name}</span>
+            <div style={{ color: '#888', fontSize: '0.85rem' }}>
+              {description}
+            </div>
+          </div>
           <PrimaryButton onClick={() => onImport(tileServer)}>
             <PlusOutlined />
             Import

--- a/react/src/components/LayersPanel/LayersPanel.tsx
+++ b/react/src/components/LayersPanel/LayersPanel.tsx
@@ -104,6 +104,7 @@ const LayersPanel: React.FC<{
     setEditLayerField({});
   }, [defaultValues]);
 
+  /** Normalize zIndex for save payload (top of list → -1, -2, -3, etc.) */
   const reorderLayers = (data: TLayerOptionsFormData) =>
     data.tileLayers.map((item, index) => ({
       ...item.layer,
@@ -120,6 +121,14 @@ const LayersPanel: React.FC<{
 
   const addTileLayer = (layer: TileServerLayer) => {
     insert(0, { layer });
+
+    // normalize zIndex for all layers (from top->-1, -2, -3 etc)
+    const values = getValues();
+    values.tileLayers.forEach((_, index) => {
+      setValue(`tileLayers.${index}.layer.uiOptions.zIndex`, -(index + 1));
+    });
+
+    //reset form to update dirty state
     reset(getValues());
   };
 
@@ -140,7 +149,9 @@ const LayersPanel: React.FC<{
     const newIndex = fields.findIndex((item) => item.id === over.id);
     move(oldIndex, newIndex);
     fields.forEach((_, index) => {
-      setValue(`tileLayers.${index}.layer.uiOptions.zIndex`, -(index + 1));
+      setValue(`tileLayers.${index}.layer.uiOptions.zIndex`, -(index + 1), {
+        shouldDirty: true,
+      });
     });
   };
 

--- a/react/src/components/Map/Map.tsx
+++ b/react/src/components/Map/Map.tsx
@@ -247,6 +247,10 @@ const LeafletMap: React.FC = () => {
             attribution={layer.attribution}
             zIndex={layer.uiOptions.zIndex}
             opacity={layer.uiOptions.opacity}
+            // Don't request tiles during zoom animation — wait until zoom settles.
+            updateWhenZooming={false}
+            // Reduce off-screen tile prefetching from default (2) to 1.
+            keepBuffer={1}
             {...layer.tileOptions} // e.g. maxZoom, minZoom, maxNativeZoom, and bounds.
             maxZoom={
               layer.internal

--- a/react/src/components/Map/Map.tsx
+++ b/react/src/components/Map/Map.tsx
@@ -247,10 +247,11 @@ const LeafletMap: React.FC = () => {
             attribution={layer.attribution}
             zIndex={layer.uiOptions.zIndex}
             opacity={layer.uiOptions.opacity}
-            // Don't request tiles during zoom animation — wait until zoom settles.
-            updateWhenZooming={false}
-            // Reduce off-screen tile prefetching from default (2) to 1.
-            keepBuffer={1}
+            //  Reduce amount of tile requests for internal layers (for https://tacc-main.atlassian.net/browse/WG-648):
+            //     * Don't request tiles during zoom animation — wait until zoom settles.
+            //     * Reduce off-screen tile prefetching from default (2) to 1.
+            updateWhenZooming={layer.internal ? false : true}
+            keepBuffer={layer.internal ? 1 : 2}
             {...layer.tileOptions} // e.g. maxZoom, minZoom, maxNativeZoom, and bounds.
             maxZoom={
               layer.internal

--- a/react/src/pages/MapProject/MapProject.tsx
+++ b/react/src/pages/MapProject/MapProject.tsx
@@ -198,8 +198,18 @@ const LoadedMapProject: React.FC<LoadedMapProject> = ({
     () => ({
       tileLayers:
         tileServerLayers
+          // Sort by zIndex (highest first) and normalize to sequential values
+          // (top of list → -1, -2, -3, etc.) to fix any duplicates from backend
           ?.sort((a, b) => b.uiOptions.zIndex - a.uiOptions.zIndex)
-          .map((layer) => ({ layer })) || [],
+          .map((layer, index) => ({
+            layer: {
+              ...layer,
+              uiOptions: {
+                ...layer.uiOptions,
+                zIndex: -(index + 1),
+              },
+            },
+          })) || [],
     }),
     [tileServerLayers]
   );


### PR DESCRIPTION
## Overview: ##

This PR Increased the CreateLayerModal width to 90vw (max 800px) to better accommodate the GeoTIFF file browser. Due to this change, I am also updating TileServerSuggestions to pair each default tile server with a short description to fill out the now even larger whitespace in the suggestions view.

This PR also fixes issues with order of layers and changes TileLayer settings:
* fixes issue with zindex order of layers
* tweaks TileLayer parameters to reduce tile requests during zoom and pan 

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

None

## Testing Steps: ##
1. Visual inspect the differences in the modal. Or see UI Photos

## UI Photos:
<img width="864" height="768" alt="Screenshot 2026-04-09 at 2 45 37 PM" src="https://github.com/user-attachments/assets/9fbed968-136b-4ebf-985a-fe76874da37d" />
<img width="881" height="376" alt="Screenshot 2026-04-09 at 2 44 48 PM" src="https://github.com/user-attachments/assets/5bc35404-660a-4540-858e-0a8b88bf4b4d" />

